### PR TITLE
Update clickhouse driver id and bump to latest release

### DIFF
--- a/server/bundles/io.cloudbeaver.resources.drivers.base/plugin.xml
+++ b/server/bundles/io.cloudbeaver.resources.drivers.base/plugin.xml
@@ -40,7 +40,7 @@
         <driver id="oracle:oracle_thin"/>
         <driver id="postgresql:postgres-jdbc"/>
         <driver id="jaybird:jaybird"/>
-        <driver id="generic:yandex_clickhouse"/>
+        <driver id="clickhouse:yandex_clickhouse"/>
         <driver id="generic:derby_server"/>
         <driver id="generic:h2_embedded"/>
         <driver id="generic:sqlite_jdbc"/>

--- a/server/drivers/clickhouse/pom.xml
+++ b/server/drivers/clickhouse/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>drivers.clickhouse</artifactId>
     <version>1.0.0</version>
@@ -18,7 +18,14 @@
         <dependency>
             <groupId>ru.yandex.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.2.6</version>
+            <classifier>shaded</classifier>
+            <version>0.3.1-patch</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Closes #424.

Also it's important to update the driver so that you can execute multi-statement script in cloudbeaver when connecting to clickhouse.