### PR TITLE
refactor(deploy/docker): use fivetran repo for docker image

### DIFF
--- a/deploy/docker/make-docker-container.sh
+++ b/deploy/docker/make-docker-container.sh
@@ -1,3 +1,3 @@
 cd ..
-docker build -t dbeaver/cloudbeaver:dev . --file ./docker/Dockerfile
+docker build -t fivetran/cloudbeaver:dev . --file ./docker/Dockerfile
 

--- a/deploy/docker/run-docker-container.sh
+++ b/deploy/docker/run-docker-container.sh
@@ -1,5 +1,5 @@
 # Detect host machine IP Address (we need this when run in docker container)
 export CB_LOCAL_HOST_ADDR=$(ifconfig | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | cut -f2 -d: | head -n1)
 
-docker run --name cloudbeaver --rm -ti -p 8978:8978 --add-host=host.docker.internal:${CB_LOCAL_HOST_ADDR} -v /var/cloudbeaver/workspace:/opt/cloudbeaver/workspace dbeaver/cloudbeaver:dev
+docker run --name cloudbeaver --rm -ti -p 8978:8978 --add-host=host.docker.internal:${CB_LOCAL_HOST_ADDR} -v /var/cloudbeaver/workspace:/opt/cloudbeaver/workspace fivetran/cloudbeaver:dev
 


### PR DESCRIPTION
This PR changes the tag generated by the included script to be `fivetran/cloudbeaver` instead of `dbeaver/cloudbeaver`.