### PR TITLE
DVO-197 commit messages validation from CE reused workflow

### DIFF
--- a/.github/workflows/commit-msgs-validator.yml
+++ b/.github/workflows/commit-msgs-validator.yml
@@ -1,0 +1,11 @@
+name: "Commit Message Validation"
+
+on: 
+  push:
+  pull_request:
+    branches:
+      - devel
+
+jobs:
+  validate-commit-message:
+    uses: dbeaver/dbeaver/.github/workflows/reused-commit-msgs-validator.yml@devel


### PR DESCRIPTION
commit message validation workflow was moved to CE repo and reuse from there

Merge [CE DVO-197 PR](https://github.com/dbeaver/dbeaver/pull/14768) first