### PR TITLE
Enhance build script

### DIFF
--- a/deploy/build-sqlite.sh
+++ b/deploy/build-sqlite.sh
@@ -1,1 +1,2 @@
-./build.sh '../config/sample-databases/SQLiteConfiguration' '../config/sample-databases/db'
+PROJECT_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+./build.sh "${PROJECT_HOME}/config/sample-databases/SQLiteConfiguration" "${PROJECT_HOME}/config/sample-databases/db"

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -1,54 +1,56 @@
 #!/bin/bash
 set -Eeuo pipefail
 
+PROJECT_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+
 #command line arguments
-CONFIGURATION_PATH=${1-"../config/sample-databases/DefaultConfiguration"}
+CONFIGURATION_PATH=${1-"${PROJECT_HOME}/config/sample-databases/DefaultConfiguration"}
 SAMPLE_DATABASE_PATH=${2-""}
 
 echo "Clone and build Cloudbeaver"
 
-rm -rf ./drivers
-rm -rf ./cloudbeaver
-mkdir ./cloudbeaver
-mkdir ./cloudbeaver/server
-mkdir ./cloudbeaver/conf
-mkdir ./cloudbeaver/workspace
-mkdir ./cloudbeaver/web
+rm -rf ${PROJECT_HOME}/deploy/drivers
+rm -rf ${PROJECT_HOME}/deploy/cloudbeaver
+mkdir ${PROJECT_HOME}/deploy/cloudbeaver
+mkdir ${PROJECT_HOME}/deploy/cloudbeaver/server
+mkdir ${PROJECT_HOME}/deploy/cloudbeaver/conf
+mkdir ${PROJECT_HOME}/deploy/cloudbeaver/workspace
+mkdir ${PROJECT_HOME}/deploy/cloudbeaver/web
 
 echo "Clone dbeaver platform"
 
-cd ../..
+cd ${PROJECT_HOME}/..
 [ ! -d dbeaver ] && git clone https://github.com/dbeaver/dbeaver.git
-cd cloudbeaver/deploy
+cd "${PROJECT_HOME}/deploy"
 
 echo "Build CloudBeaver server"
 
-cd ../server/product/aggregate
+cd ${PROJECT_HOME}/server/product/aggregate
 mvn clean package -Dheadless-platform
 if [[ "$?" -ne 0 ]] ; then
   echo 'Could not perform package'; exit $rc
 fi
-cd ../../../deploy
+cd ${PROJECT_HOME}/deploy
 
 echo "Copy server packages"
 
-cp -rp ../server/product/web-server/target/products/io.cloudbeaver.product/all/all/all/* ./cloudbeaver/server
-cp -p ./scripts/* ./cloudbeaver
-mkdir cloudbeaver/samples
+cp -rp ${PROJECT_HOME}/server/product/web-server/target/products/io.cloudbeaver.product/all/all/all/* ${PROJECT_HOME}/deploy/cloudbeaver/server
+cp -p ${PROJECT_HOME}/deploy/scripts/* ${PROJECT_HOME}/deploy/cloudbeaver
+mkdir ${PROJECT_HOME}/deploy/cloudbeaver/samples
 
 if [[ ! -z "${SAMPLE_DATABASE_PATH}"  ]]; then
-  mkdir cloudbeaver/samples/db
-  cp -rp "${SAMPLE_DATABASE_PATH}" cloudbeaver/samples/
+  mkdir ${PROJECT_HOME}/deploy/cloudbeaver/samples/db
+  cp -rp ${SAMPLE_DATABASE_PATH} ${PROJECT_HOME}/deploy/cloudbeaver/samples/
 fi
 
-cp -rp  ../config/core/* cloudbeaver/conf
-cp -rp "${CONFIGURATION_PATH}"/GlobalConfiguration/.dbeaver/data-sources.json cloudbeaver/conf/initial-data-sources.conf
-cp -p "${CONFIGURATION_PATH}"/*.conf cloudbeaver/conf/
-mv drivers cloudbeaver
+cp -rp ${PROJECT_HOME}/config/core/* ${PROJECT_HOME}/deploy/cloudbeaver/conf
+cp -rp ${CONFIGURATION_PATH}/GlobalConfiguration/.dbeaver/data-sources.json ${PROJECT_HOME}/deploy/cloudbeaver/conf/initial-data-sources.conf
+cp -p ${CONFIGURATION_PATH}/*.conf ${PROJECT_HOME}/deploy/cloudbeaver/conf/
+mv ${PROJECT_HOME}/deploy/drivers ${PROJECT_HOME}/deploy/cloudbeaver
 
 echo "Build static content"
 
-cd ../webapp
+cd ${PROJECT_HOME}/webapp
 
 yarn
 lerna run bootstrap
@@ -57,10 +59,10 @@ if [[ "$?" -ne 0 ]] ; then
   echo 'Application build failed'; exit $rc
 fi
 
-cd ../deploy
+cd ${PROJECT_HOME}/deploy
 
 echo "Copy static content"
 
-cp -rp ../webapp/packages/product-default/lib/* cloudbeaver/web
+cp -rp ${PROJECT_HOME}/webapp/packages/product-default/lib/* ${PROJECT_HOME}/deploy/cloudbeaver/web
 
-echo "Cloudbeaver is ready. Run run-server.bat in cloudbeaver folder to start the server."
+echo "Cloudbeaver is ready. Run run-server.sh in ${PROJECT_HOME}/deploy/cloudbeaver folder to start the server."


### PR DESCRIPTION
Currently, user must run `cd deploy` before building the project.

This PR enhances the build script to make build script can run from any folder.

PS: I don't touch `bat` because I am not familiar with that language and don't have Windows machine to test.