### PR TITLE
CB-2733 remove the cause of browser reflow

### DIFF
--- a/webapp/packages/plugin-data-viewer/src/ValuePanelPresentation/ValuePanelTools/VALUE_PANEL_TOOLS_STYLES.ts
+++ b/webapp/packages/plugin-data-viewer/src/ValuePanelPresentation/ValuePanelTools/VALUE_PANEL_TOOLS_STYLES.ts
@@ -27,7 +27,7 @@ export const VALUE_PANEL_TOOLS_STYLES = css`
     cursor: pointer;
     padding: 4px;
     width: 24px;
-    height: 100%;
+    height: auto;
   }
   IconOrImage {
     width: 100%;


### PR DESCRIPTION
When an image loads, it goes from a height of 0 pixels to whatever it needs to be. This causes reflow, where the content below or around the image gets pushed to make room for the freshly loaded image. Reflow is a problem it’s a user-blocking operation. It slows down the browser by forcing it to recalculate the layout of any elements that are affected by that image’s shape. We force aspect ratio to avoid this issue.