### PR TITLE
CB-2706 allow copy from sql editor in readonly mode

### DIFF
--- a/webapp/packages/plugin-codemirror/src/CodeEditor.tsx
+++ b/webapp/packages/plugin-codemirror/src/CodeEditor.tsx
@@ -21,13 +21,14 @@ import 'codemirror/addon/selection/mark-selection';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/addon/hint/show-hint.css';
 
-
-
 import { useStyles } from '@cloudbeaver/core-blocks';
 
 import type { ICodeEditorProps } from './ICodeEditorProps';
 import { SqlEditorStyles } from './theme';
 import { useAutoFormat } from './useAutoFormat';
+
+/** We use hardcoded value because codemirror treats undefined and lack of prop diffrently  */
+export const DEFAULT_CURSOR_BLINK_RATE = 530;
 
 export const CodeEditor = observer<ICodeEditorProps>(function CodeEditor(props) {
   const { autoFormat, className, editorDidMount } = props;
@@ -73,7 +74,11 @@ export const CodeEditor = observer<ICodeEditorProps>(function CodeEditor(props) 
         {...props}
         value={value}
         editorDidMount={handleMount}
-        options={{ styleSelectedText: true, ...props.options }}
+        options={{
+          styleSelectedText: true,
+          ...props.options,
+          cursorBlinkRate: props.options?.cursorBlinkRate ?? DEFAULT_CURSOR_BLINK_RATE,
+        }}
       />
     </code-editor>
   );

--- a/webapp/packages/plugin-codemirror/src/CodeEditorLoader.tsx
+++ b/webapp/packages/plugin-codemirror/src/CodeEditorLoader.tsx
@@ -10,8 +10,6 @@ import { ComplexLoader, createComplexLoader, Loader } from '@cloudbeaver/core-bl
 
 import type { ICodeEditorProps } from './ICodeEditorProps';
 
-export const DEFAULT_CURSOR_BLINK_RATE = 530;
-
 const loader = createComplexLoader(async function loader() {
   const { CodeEditor } = await import('./CodeEditor');
   return { CodeEditor };

--- a/webapp/packages/plugin-codemirror/src/CodeEditorLoader.tsx
+++ b/webapp/packages/plugin-codemirror/src/CodeEditorLoader.tsx
@@ -10,6 +10,8 @@ import { ComplexLoader, createComplexLoader, Loader } from '@cloudbeaver/core-bl
 
 import type { ICodeEditorProps } from './ICodeEditorProps';
 
+export const DEFAULT_CURSOR_BLINK_RATE = 530;
+
 const loader = createComplexLoader(async function loader() {
   const { CodeEditor } = await import('./CodeEditor');
   return { CodeEditor };

--- a/webapp/packages/plugin-data-viewer/src/ValuePanelPresentation/TextValue/TextValuePresentation.tsx
+++ b/webapp/packages/plugin-data-viewer/src/ValuePanelPresentation/TextValue/TextValuePresentation.tsx
@@ -16,7 +16,7 @@ import { NotificationService } from '@cloudbeaver/core-events';
 import { QuotasService } from '@cloudbeaver/core-root';
 import { BASE_TAB_STYLES, TabContainerPanelComponent, TabList, TabsState, UNDERLINE_TAB_STYLES } from '@cloudbeaver/core-ui';
 import { bytesToSize } from '@cloudbeaver/core-utils';
-import { CodeEditorLoader, DEFAULT_CURSOR_BLINK_RATE } from '@cloudbeaver/plugin-codemirror';
+import { CodeEditorLoader } from '@cloudbeaver/plugin-codemirror';
 
 import type { IResultSetElementKey } from '../../DatabaseDataModel/Actions/ResultSet/IResultSetDataKey';
 import { isResultSetContentValue } from '../../DatabaseDataModel/Actions/ResultSet/isResultSetContentValue';
@@ -194,7 +194,7 @@ export const TextValuePresentation: TabContainerPanelComponent<IDataValuePanelPr
             mode: state.currentContentType,
             theme: 'material',
             readOnly: readonly,
-            cursorBlinkRate: readonly ? -1 : DEFAULT_CURSOR_BLINK_RATE,
+            cursorBlinkRate: readonly ? -1 : undefined,
             lineNumbers: true,
             indentWithTabs: true,
             smartIndent: true,

--- a/webapp/packages/plugin-data-viewer/src/ValuePanelPresentation/TextValue/TextValuePresentation.tsx
+++ b/webapp/packages/plugin-data-viewer/src/ValuePanelPresentation/TextValue/TextValuePresentation.tsx
@@ -16,7 +16,7 @@ import { NotificationService } from '@cloudbeaver/core-events';
 import { QuotasService } from '@cloudbeaver/core-root';
 import { BASE_TAB_STYLES, TabContainerPanelComponent, TabList, TabsState, UNDERLINE_TAB_STYLES } from '@cloudbeaver/core-ui';
 import { bytesToSize } from '@cloudbeaver/core-utils';
-import { CodeEditorLoader } from '@cloudbeaver/plugin-codemirror';
+import { CodeEditorLoader, DEFAULT_CURSOR_BLINK_RATE } from '@cloudbeaver/plugin-codemirror';
 
 import type { IResultSetElementKey } from '../../DatabaseDataModel/Actions/ResultSet/IResultSetDataKey';
 import { isResultSetContentValue } from '../../DatabaseDataModel/Actions/ResultSet/isResultSetContentValue';
@@ -193,7 +193,8 @@ export const TextValuePresentation: TabContainerPanelComponent<IDataValuePanelPr
           options={{
             mode: state.currentContentType,
             theme: 'material',
-            readOnly: readonly ? 'nocursor' : false,
+            readOnly: readonly,
+            cursorBlinkRate: readonly ? -1 : DEFAULT_CURSOR_BLINK_RATE,
             lineNumbers: true,
             indentWithTabs: true,
             smartIndent: true,

--- a/webapp/packages/plugin-sql-editor/src/SqlEditor/SQLCodeEditor/SQLCodeEditor.tsx
+++ b/webapp/packages/plugin-sql-editor/src/SqlEditor/SQLCodeEditor/SQLCodeEditor.tsx
@@ -10,7 +10,7 @@ import { observer } from 'mobx-react-lite';
 import { forwardRef, useImperativeHandle, useMemo } from 'react';
 
 import { useController } from '@cloudbeaver/core-di';
-import { CodeEditorLoader, DEFAULT_CURSOR_BLINK_RATE } from '@cloudbeaver/plugin-codemirror';
+import { CodeEditorLoader } from '@cloudbeaver/plugin-codemirror';
 
 import type { ISQLCodeEditorProps } from './ISQLCodeEditorProps';
 import { SQLCodeEditorController } from './SQLCodeEditorController';
@@ -31,7 +31,7 @@ export const SQLCodeEditor = observer<ISQLCodeEditorProps, SQLCodeEditorControll
       {...controller.bindings}
       options={{
         readOnly: props.readonly,
-        cursorBlinkRate: props.readonly ? -1 : DEFAULT_CURSOR_BLINK_RATE,
+        cursorBlinkRate: props.readonly ? -1 : undefined,
         ...controller.bindings.options,
         mode: controller.mode,
       }}

--- a/webapp/packages/plugin-sql-editor/src/SqlEditor/SQLCodeEditor/SQLCodeEditor.tsx
+++ b/webapp/packages/plugin-sql-editor/src/SqlEditor/SQLCodeEditor/SQLCodeEditor.tsx
@@ -10,7 +10,7 @@ import { observer } from 'mobx-react-lite';
 import { forwardRef, useImperativeHandle, useMemo } from 'react';
 
 import { useController } from '@cloudbeaver/core-di';
-import { CodeEditorLoader } from '@cloudbeaver/plugin-codemirror';
+import { CodeEditorLoader, DEFAULT_CURSOR_BLINK_RATE } from '@cloudbeaver/plugin-codemirror';
 
 import type { ISQLCodeEditorProps } from './ISQLCodeEditorProps';
 import { SQLCodeEditorController } from './SQLCodeEditorController';
@@ -30,7 +30,8 @@ export const SQLCodeEditor = observer<ISQLCodeEditorProps, SQLCodeEditorControll
     <CodeEditorLoader
       {...controller.bindings}
       options={{
-        readOnly: props.readonly ? 'nocursor' : false,
+        readOnly: props.readonly,
+        cursorBlinkRate: props.readonly ? -1 : DEFAULT_CURSOR_BLINK_RATE,
         ...controller.bindings.options,
         mode: controller.mode,
       }}


### PR DESCRIPTION
You can't focus the editor with the settings 'nocursor', so there is no way to have copy work (browser will only send copy events to focused elements). So we just hide cursor in readonly mode to mimic this behaviour.