### PR TITLE
Upgrade ClickHouse JDBC driver to 0.4.6

### DIFF
--- a/server/drivers/clickhouse_com/pom.xml
+++ b/server/drivers/clickhouse_com/pom.xml
@@ -18,8 +18,7 @@
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.3.2-patch7</version>
+            <version>0.4.6</version>
         </dependency>
     </dependencies>
-
 </project>


### PR DESCRIPTION
This is a followup PR to fix dbeaver/dbeaver#19868.

If there's concern about size(25MB+), please add `<classifier>shaded</classifier>` to use the ~3.3MB uber jar. If it's still too large, try `<classifier>http</classifier>` which is ~1.2MB.