### PR TITLE
dbeaver/dbeaver-devops#635 non root images

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -3,6 +3,6 @@ FROM eclipse-temurin:17.0.4.1_1-jre-focal
 COPY cloudbeaver /opt/cloudbeaver
 
 EXPOSE 8978
-
+RUN find /opt -type d -exec chmod 775 {} \;
 WORKDIR /opt/cloudbeaver/
 ENTRYPOINT ["./run-server.sh"]

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -3,6 +3,6 @@ FROM eclipse-temurin:17.0.4.1_1-jre-focal
 COPY cloudbeaver /opt/cloudbeaver
 
 EXPOSE 8978
-RUN find /opt -type d -exec chmod 775 {} \;
+RUN find /opt/cloudbeaver -type d -exec chmod 775 {} \;
 WORKDIR /opt/cloudbeaver/
 ENTRYPOINT ["./run-server.sh"]


### PR DESCRIPTION
Openshift deployment support.

We need change ownership of all folderes in /opt catalog  to 775