### PR TITLE
CB-4059 do not verify the SSL Certificate of the target server in dev…

### DIFF
--- a/webapp/packages/core-cli/configs/webpack.product.dev.config.js
+++ b/webapp/packages/core-cli/configs/webpack.product.dev.config.js
@@ -61,10 +61,12 @@ module.exports = (env, argv) => {
       proxy: {
         '/api': {
           target: envServer,
+          secure: false,
         },
         '/api/ws': {
           target: `${urlObject.protocol === 'https:' ? 'wss:' : 'ws:'}//${urlObject.hostname}:${urlObject.port}/api/ws`,
           ws: true,
+          secure: false,
         },
       },
       onListening: function (devServer, ...args) {


### PR DESCRIPTION
Secure is set to false, which means that the proxy will not verify the SSL Certificate of the server specified in target (envServer) and will forward the request even if the certificate is invalid or untrusted. Use only in dev mode