### PR TITLE
CB-4111 take as much width as needed in inline mode

### DIFF
--- a/webapp/packages/core-blocks/src/FormControls/Combobox.m.css
+++ b/webapp/packages/core-blocks/src/FormControls/Combobox.m.css
@@ -5,6 +5,7 @@
   & .fieldLabel {
     padding-right: 8px;
     padding-bottom: 0;
+    width: max-content;
   }
 }
 

--- a/webapp/packages/plugin-codemirror6/src/theme/_base-code-editor.scss
+++ b/webapp/packages/plugin-codemirror6/src/theme/_base-code-editor.scss
@@ -59,7 +59,8 @@
     @include mdc-theme-prop(border-color, background, false);
   }
 
-  .cm-panels-top {
+  .cm-panels-top,
+  .cm-panels-bottom {
     @include mdc-theme-prop(border-color, background, false);
   }
 


### PR DESCRIPTION
label used to be a div, now its an label and takes 100% of the width (global styles), we do not want it for the combobox inline mode