### PR TITLE
Added French translation file (fr.ts)

### DIFF
--- a/webapp/packages/core-app/src/locales/fr.ts
+++ b/webapp/packages/core-app/src/locales/fr.ts
@@ -1,0 +1,11 @@
+export default [
+  ['app_shared_settingsMenu_config', 'Configuration'],
+  ['app_shared_settingsMenu_theme', 'Thème'],
+  ['app_shared_settingsMenu_lang', 'Langue'],
+  ['app_shared_inlineEditor_dialog_title', 'Mode Edition'],
+  ['app_shared_inlineEditor_dialog_apply', 'Appliquer'],
+  ['app_shared_inlineEditor_dialog_cancel', 'Annuler'],
+  ['app_shared_navigationTabsBar_placeholder', 'Il n’y a aucun objet à afficher. Double-cliquez sur un objet dans l’arborescence de navigation pour l’ouvrir.'],
+  ['app_shared_sql_generators_panel_title', 'Générer du SQL'],
+  ['app_shared_sql_generators_dialog_title', 'SQL Généré'],
+];


### PR DESCRIPTION
I have added the fr.ts file to the cloudbeaver/webapp/packages/core-app/src/locales/ directory. This file contains the French translations for various strings used in the application. The translations include settings, theme, language, dialog titles and messages, as well as labels for SQL generation.