### PR TITLE
CB-6000 handle task info events from WS

### DIFF
--- a/webapp/packages/core-connections/src/ConnectionExecutionContext/ConnectionExecutionContext.ts
+++ b/webapp/packages/core-connections/src/ConnectionExecutionContext/ConnectionExecutionContext.ts
@@ -8,7 +8,8 @@
 import { computed, makeObservable, observable } from 'mobx';
 
 import type { ITask, TaskScheduler } from '@cloudbeaver/core-executor';
-import type { AsyncTaskInfo, AsyncTaskInfoService, GraphQLService } from '@cloudbeaver/core-sdk';
+import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import type { AsyncTaskInfo, GraphQLService } from '@cloudbeaver/core-sdk';
 
 import type { ConnectionExecutionContextResource, IConnectionExecutionContextInfo } from './ConnectionExecutionContextResource.js';
 import type { IConnectionExecutionContext } from './IConnectionExecutionContext.js';

--- a/webapp/packages/core-connections/src/ConnectionExecutionContext/ConnectionExecutionContext.ts
+++ b/webapp/packages/core-connections/src/ConnectionExecutionContext/ConnectionExecutionContext.ts
@@ -8,7 +8,7 @@
 import { computed, makeObservable, observable } from 'mobx';
 
 import type { ITask, TaskScheduler } from '@cloudbeaver/core-executor';
-import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { AsyncTaskInfoService } from '@cloudbeaver/core-root';
 import type { AsyncTaskInfo, GraphQLService } from '@cloudbeaver/core-sdk';
 
 import type { ConnectionExecutionContextResource, IConnectionExecutionContextInfo } from './ConnectionExecutionContextResource.js';

--- a/webapp/packages/core-connections/src/ConnectionExecutionContext/ConnectionExecutionContextService.ts
+++ b/webapp/packages/core-connections/src/ConnectionExecutionContext/ConnectionExecutionContextService.ts
@@ -8,7 +8,7 @@
 import { injectable } from '@cloudbeaver/core-di';
 import { TaskScheduler } from '@cloudbeaver/core-executor';
 import { CachedMapAllKey, ResourceKeyUtils } from '@cloudbeaver/core-resource';
-import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { AsyncTaskInfoService } from '@cloudbeaver/core-root';
 import { GraphQLService } from '@cloudbeaver/core-sdk';
 import { MetadataMap } from '@cloudbeaver/core-utils';
 

--- a/webapp/packages/core-connections/src/ConnectionExecutionContext/ConnectionExecutionContextService.ts
+++ b/webapp/packages/core-connections/src/ConnectionExecutionContext/ConnectionExecutionContextService.ts
@@ -8,7 +8,8 @@
 import { injectable } from '@cloudbeaver/core-di';
 import { TaskScheduler } from '@cloudbeaver/core-executor';
 import { CachedMapAllKey, ResourceKeyUtils } from '@cloudbeaver/core-resource';
-import { AsyncTaskInfoService, GraphQLService } from '@cloudbeaver/core-sdk';
+import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { GraphQLService } from '@cloudbeaver/core-sdk';
 import { MetadataMap } from '@cloudbeaver/core-utils';
 
 import type { IConnectionInfoParams } from '../CONNECTION_INFO_PARAM_SCHEMA.js';

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTask.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTask.ts
@@ -8,7 +8,7 @@
 import { computed, makeObservable, observable } from 'mobx';
 
 import { type ISyncExecutor, SyncExecutor } from '@cloudbeaver/core-executor';
-import { type AsyncTaskInfo, ServerInternalError } from '@cloudbeaver/core-sdk';
+import { type AsyncTaskInfo, ServerInternalError, type WsAsyncTaskInfo } from '@cloudbeaver/core-sdk';
 
 export class AsyncTask {
   get id(): string {
@@ -125,9 +125,11 @@ export class AsyncTask {
     }
   }
 
-  public updateStatus(info: AsyncTaskInfo): void {
-    this.taskInfo = info;
-    this.onStatusChange.execute(this.taskInfo);
+  public updateStatus(info: WsAsyncTaskInfo): void {
+    if (this.taskInfo) {
+      this.taskInfo.status = info.statusName;
+      this.onStatusChange.execute(this.taskInfo);
+    }
   }
 
   private updateInfo(info: AsyncTaskInfo): void {

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTask.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTask.ts
@@ -8,10 +8,8 @@
 import { computed, makeObservable, observable } from 'mobx';
 
 import { type ISyncExecutor, SyncExecutor } from '@cloudbeaver/core-executor';
+import { type AsyncTaskInfo, ServerInternalError } from '@cloudbeaver/core-sdk';
 import { uuid } from '@cloudbeaver/core-utils';
-
-import type { AsyncTaskInfo } from '../sdk.js';
-import { ServerInternalError } from '../ServerInternalError.js';
 
 export class AsyncTask {
   readonly id: string;

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTask.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTask.ts
@@ -47,10 +47,10 @@ export class AsyncTask {
   private readonly innerPromise: Promise<AsyncTaskInfo>;
   private updatingAsync: boolean;
   private readonly init: () => Promise<AsyncTaskInfo>;
-  private readonly cancel: (info: AsyncTaskInfo) => Promise<void>;
+  private readonly cancel: (id: string) => Promise<void>;
   private initPromise: Promise<void> | null;
 
-  constructor(init: () => Promise<AsyncTaskInfo>, cancel: (info: AsyncTaskInfo) => Promise<void>) {
+  constructor(init: () => Promise<AsyncTaskInfo>, cancel: (id: string) => Promise<void>) {
     this._id = '';
     this.init = init;
     this.cancel = cancel;
@@ -125,6 +125,11 @@ export class AsyncTask {
     }
   }
 
+  public updateStatus(info: AsyncTaskInfo): void {
+    this.taskInfo = info;
+    this.onStatusChange.execute(this.taskInfo);
+  }
+
   private updateInfo(info: AsyncTaskInfo): void {
     this.taskInfo = info;
 
@@ -139,8 +144,6 @@ export class AsyncTask {
   }
 
   private async cancelTask(): Promise<void> {
-    if (this.info) {
-      await this.cancel(this.info);
-    }
+    await this.cancel(this.id);
   }
 }

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTask.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTask.ts
@@ -9,10 +9,17 @@ import { computed, makeObservable, observable } from 'mobx';
 
 import { type ISyncExecutor, SyncExecutor } from '@cloudbeaver/core-executor';
 import { type AsyncTaskInfo, ServerInternalError } from '@cloudbeaver/core-sdk';
-import { uuid } from '@cloudbeaver/core-utils';
 
 export class AsyncTask {
-  readonly id: string;
+  get id(): string {
+    return this._id;
+  }
+
+  set id(id: string) {
+    if (!this._id) {
+      this._id = id;
+    }
+  }
 
   get cancelled(): boolean {
     return this._cancelled;
@@ -32,6 +39,7 @@ export class AsyncTask {
 
   readonly onStatusChange: ISyncExecutor<AsyncTaskInfo>;
 
+  private _id: string;
   private _cancelled: boolean;
   private taskInfo: AsyncTaskInfo | null;
   private resolve!: (value: AsyncTaskInfo) => void;
@@ -43,7 +51,7 @@ export class AsyncTask {
   private initPromise: Promise<void> | null;
 
   constructor(init: () => Promise<AsyncTaskInfo>, cancel: (info: AsyncTaskInfo) => Promise<void>) {
-    this.id = uuid();
+    this._id = '';
     this.init = init;
     this.cancel = cancel;
     this._cancelled = false;

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTask.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTask.ts
@@ -9,18 +9,9 @@ import { computed, makeObservable, observable } from 'mobx';
 
 import { type ISyncExecutor, SyncExecutor } from '@cloudbeaver/core-executor';
 import { type AsyncTaskInfo, ServerInternalError, type WsAsyncTaskInfo } from '@cloudbeaver/core-sdk';
+import { uuid } from '@cloudbeaver/core-utils';
 
 export class AsyncTask {
-  get id(): string {
-    return this._id;
-  }
-
-  set id(id: string) {
-    if (!this._id) {
-      this._id = id;
-    }
-  }
-
   get cancelled(): boolean {
     return this._cancelled;
   }
@@ -37,6 +28,10 @@ export class AsyncTask {
     return this.innerPromise;
   }
 
+  get id(): string {
+    return this._id;
+  }
+
   readonly onStatusChange: ISyncExecutor<AsyncTaskInfo>;
 
   private _id: string;
@@ -51,7 +46,7 @@ export class AsyncTask {
   private initPromise: Promise<void> | null;
 
   constructor(init: () => Promise<AsyncTaskInfo>, cancel: (id: string) => Promise<void>) {
-    this._id = '';
+    this._id = uuid();
     this.init = init;
     this.cancel = cancel;
     this._cancelled = false;
@@ -146,6 +141,8 @@ export class AsyncTask {
   }
 
   private async cancelTask(): Promise<void> {
-    await this.cancel(this.id);
+    if (this.info) {
+      await this.cancel(this.info.id);
+    }
   }
 }

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoEventHandler.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoEventHandler.ts
@@ -1,0 +1,23 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+import { injectable } from '@cloudbeaver/core-di';
+import type { WsAsyncTaskInfo } from '@cloudbeaver/core-sdk';
+
+import { TopicEventHandler } from '../ServerEventEmitter/TopicEventHandler.js';
+import { type ISessionEvent, type SessionEventId, SessionEventSource, SessionEventTopic } from '../SessionEventSource.js';
+
+@injectable()
+export class AsyncTaskInfoEventHandler extends TopicEventHandler<WsAsyncTaskInfo, ISessionEvent, SessionEventId, SessionEventTopic> {
+  constructor(sessionEventSource: SessionEventSource) {
+    super(SessionEventTopic.CbSessionTask, sessionEventSource);
+  }
+
+  map(event: any): WsAsyncTaskInfo {
+    return event;
+  }
+}

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
@@ -31,9 +31,19 @@ export class AsyncTaskInfoService extends Disposable {
 
     this.onEventUnsubscribe = asyncTaskInfoEventHandler.onEvent<WsAsyncTaskInfo>(ServerEventId.CbSessionTaskInfoUpdated, async data => {
       const task = this.tasks.get(data.taskId);
-      console.log(task);
 
-      await task?.updateInfoAsync(async () => data);
+      if (data.running === false) {
+        await task?.updateInfoAsync(async () => {
+          const { taskInfo } = await this.graphQLService.sdk.getAsyncTaskInfo({
+            taskId: data.taskId,
+            removeOnFinish: false,
+          });
+
+          return taskInfo;
+        });
+      } else {
+        task?.updateStatus(data);
+      }
     });
   }
 
@@ -47,7 +57,6 @@ export class AsyncTaskInfoService extends Disposable {
       const info = await getter();
       if (info.id && !this.tasks.has(info.id)) {
         this.tasks.set(info.id, task);
-        console.log(this.tasks);
         task.id = info.id;
         if (this.tasks.size === 1) {
           this.connection = this.asyncTaskInfoEventHandler.eventsSubject.connect();
@@ -88,7 +97,7 @@ export class AsyncTaskInfoService extends Disposable {
 
     if (task.info !== null) {
       await this.graphQLService.sdk.getAsyncTaskInfo({
-        taskId: task.info.id,
+        taskId: task.id,
         removeOnFinish: true,
       });
     }
@@ -100,9 +109,9 @@ export class AsyncTaskInfoService extends Disposable {
     await task?.cancelAsync();
   }
 
-  private async cancelTask(info: AsyncTaskInfo): Promise<void> {
+  private async cancelTask(id: string): Promise<void> {
     await this.graphQLService.sdk.asyncTaskCancel({
-      taskId: info.id,
+      taskId: id,
     });
   }
 }

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
@@ -6,10 +6,9 @@
  * you may not use this file except in compliance with the License.
  */
 import { injectable } from '@cloudbeaver/core-di';
+import { type AsyncTaskInfo, GraphQLService } from '@cloudbeaver/core-sdk';
 import { cancellableTimeout } from '@cloudbeaver/core-utils';
 
-import { GraphQLService } from '../GraphQLService.js';
-import type { AsyncTaskInfo } from '../sdk.js';
 import { AsyncTask } from './AsyncTask.js';
 
 const DELAY_BETWEEN_TRIES = 250;

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
@@ -73,14 +73,16 @@ export class AsyncTaskInfoService extends Disposable {
 
     this.tasks.set(task.id, task);
     task.onStatusChange.addHandler(info => {
+      if (this.taskIdAliases.get(info.id)) {
+        return;
+      }
+
+      this.taskIdAliases.set(info.id, task.id);
+
       const pendingEvent = this.pendingEvents.get(info.id);
       if (pendingEvent) {
-        const changes = { ...pendingEvent };
         this.pendingEvents.delete(info.id);
-        this.updateTask(task, changes);
-      }
-      if (!this.taskIdAliases.get(info.id)) {
-        this.taskIdAliases.set(info.id, task.id);
+        this.updateTask(task, pendingEvent);
       }
     });
 

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
@@ -18,6 +18,7 @@ import { AsyncTaskInfoEventHandler } from './AsyncTaskInfoEventHandler.js';
 @injectable()
 export class AsyncTaskInfoService extends Disposable {
   private readonly tasks: Map<string, AsyncTask>;
+  private readonly taskIdAliases: Map<string, string>;
   private connection: Subscription | null;
   private onEventUnsubscribe: Unsubscribe | null;
 
@@ -27,10 +28,11 @@ export class AsyncTaskInfoService extends Disposable {
   ) {
     super();
     this.tasks = new Map();
+    this.taskIdAliases = new Map();
     this.connection = null;
 
     this.onEventUnsubscribe = asyncTaskInfoEventHandler.onEvent<WsAsyncTaskInfo>(ServerEventId.CbSessionTaskInfoUpdated, async data => {
-      const task = this.tasks.get(data.taskId);
+      const task = this.getTask(data.taskId);
 
       if (data.running === false) {
         await task?.updateInfoAsync(async () => {
@@ -53,18 +55,29 @@ export class AsyncTaskInfoService extends Disposable {
   }
 
   create(getter: () => Promise<AsyncTaskInfo>): AsyncTask {
-    const task = new AsyncTask(async () => {
-      const info = await getter();
-      if (info.id && !this.tasks.has(info.id)) {
-        this.tasks.set(info.id, task);
-        task.id = info.id;
-        if (this.tasks.size === 1) {
-          this.connection = this.asyncTaskInfoEventHandler.eventsSubject.connect();
-        }
-      }
+    const task = new AsyncTask(getter, this.cancelTask.bind(this));
+    this.tasks.set(task.id, task);
+    task.onStatusChange.addHandler(info => {
+      this.taskIdAliases.set(info.id, task.id);
+    });
 
-      return info;
-    }, this.cancelTask.bind(this));
+    if (this.tasks.size === 1) {
+      this.connection = this.asyncTaskInfoEventHandler.eventsSubject.connect();
+    }
+
+    return task;
+  }
+
+  private getTask(taskId: string): AsyncTask | undefined {
+    let task = this.tasks.get(taskId);
+
+    if (!task) {
+      const internalId = this.taskIdAliases.get(taskId);
+
+      if (internalId) {
+        task = this.tasks.get(internalId);
+      }
+    }
 
     return task;
   }
@@ -78,7 +91,7 @@ export class AsyncTaskInfoService extends Disposable {
   }
 
   async remove(taskId: string): Promise<void> {
-    const task = this.tasks.get(taskId);
+    const task = this.getTask(taskId);
 
     if (!task) {
       return;
@@ -87,9 +100,10 @@ export class AsyncTaskInfoService extends Disposable {
     if (task.pending) {
       throw new Error('Cant remove unfinished task');
     }
-
-    this.tasks.delete(taskId);
-
+    this.tasks.delete(task.id);
+    if (task.info) {
+      this.taskIdAliases.delete(task.info.id);
+    }
     if (this.tasks.size === 0) {
       this.connection?.unsubscribe();
       this.connection = null;
@@ -97,14 +111,14 @@ export class AsyncTaskInfoService extends Disposable {
 
     if (task.info !== null) {
       await this.graphQLService.sdk.getAsyncTaskInfo({
-        taskId: task.id,
+        taskId: task.info.id,
         removeOnFinish: true,
       });
     }
   }
 
   async cancel(taskId: string): Promise<void> {
-    const task = this.tasks.get(taskId);
+    const task = this.getTask(taskId);
 
     await task?.cancelAsync();
   }

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
@@ -10,6 +10,7 @@ import type { Subscription } from 'rxjs';
 import { Disposable, injectable } from '@cloudbeaver/core-di';
 import { type AsyncTaskInfo, GraphQLService, type WsAsyncTaskInfo } from '@cloudbeaver/core-sdk';
 
+import type { Unsubscribe } from '../ServerEventEmitter/IServerEventEmitter.js';
 import { ServerEventId } from '../SessionEventSource.js';
 import { AsyncTask } from './AsyncTask.js';
 import { AsyncTaskInfoEventHandler } from './AsyncTaskInfoEventHandler.js';
@@ -18,7 +19,7 @@ import { AsyncTaskInfoEventHandler } from './AsyncTaskInfoEventHandler.js';
 export class AsyncTaskInfoService extends Disposable {
   private readonly tasks: Map<string, AsyncTask>;
   private connection: Subscription | null;
-  private onEvent: any;
+  private onEventUnsubscribe: Unsubscribe | null;
 
   constructor(
     private readonly graphQLService: GraphQLService,
@@ -28,35 +29,33 @@ export class AsyncTaskInfoService extends Disposable {
     this.tasks = new Map();
     this.connection = null;
 
-    this.onEvent = asyncTaskInfoEventHandler.onEvent<WsAsyncTaskInfo>(ServerEventId.CbSessionTaskInfoUpdated, async data => {
-      console.log('onEvent', data);
-      // const task = this.tasks.get(data.taskId);
+    this.onEventUnsubscribe = asyncTaskInfoEventHandler.onEvent<WsAsyncTaskInfo>(ServerEventId.CbSessionTaskInfoUpdated, async data => {
+      const task = this.tasks.get(data.taskId);
+      console.log(task);
 
-      // if (task?.pending && task.info) {
-      //   await task.updateInfoAsync(async task => {
-      //     const { taskInfo } = await this.graphQLService.sdk.getAsyncTaskInfo({
-      //       taskId: task.info!.id,
-      //       removeOnFinish: false,
-      //     });
-
-      //     return taskInfo;
-      //   });
-      // }
+      await task?.updateInfoAsync(async () => data);
     });
   }
 
   override dispose(): void {
     this.connection?.unsubscribe();
-    this.onEvent.dispose();
+    this.onEventUnsubscribe?.();
   }
 
   create(getter: () => Promise<AsyncTaskInfo>): AsyncTask {
-    const task = new AsyncTask(getter, this.cancelTask.bind(this));
-    this.tasks.set(task.id, task);
+    const task = new AsyncTask(async () => {
+      const info = await getter();
+      if (info.id && !this.tasks.has(info.id)) {
+        this.tasks.set(info.id, task);
+        console.log(this.tasks);
+        task.id = info.id;
+        if (this.tasks.size === 1) {
+          this.connection = this.asyncTaskInfoEventHandler.eventsSubject.connect();
+        }
+      }
 
-    if (this.tasks.size === 1) {
-      this.connection = this.asyncTaskInfoEventHandler.eventsSubject.connect();
-    }
+      return info;
+    }, this.cancelTask.bind(this));
 
     return task;
   }

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
@@ -19,6 +19,7 @@ import { AsyncTaskInfoEventHandler } from './AsyncTaskInfoEventHandler.js';
 export class AsyncTaskInfoService extends Disposable {
   private readonly tasks: Map<string, AsyncTask>;
   private readonly taskIdAliases: Map<string, string>;
+  private readonly pendingEvents: Map<string, WsAsyncTaskInfo>;
   private connection: Subscription | null;
   private onEventUnsubscribe: Unsubscribe | null;
 
@@ -29,24 +30,37 @@ export class AsyncTaskInfoService extends Disposable {
     super();
     this.tasks = new Map();
     this.taskIdAliases = new Map();
+    this.pendingEvents = new Map();
     this.connection = null;
+    this.handleEvent = this.handleEvent.bind(this);
 
-    this.onEventUnsubscribe = asyncTaskInfoEventHandler.onEvent<WsAsyncTaskInfo>(ServerEventId.CbSessionTaskInfoUpdated, async data => {
-      const task = this.getTask(data.taskId);
+    this.onEventUnsubscribe = asyncTaskInfoEventHandler.onEvent<WsAsyncTaskInfo>(ServerEventId.CbSessionTaskInfoUpdated, this.handleEvent);
+  }
 
-      if (data.running === false) {
-        await task?.updateInfoAsync(async () => {
-          const { taskInfo } = await this.graphQLService.sdk.getAsyncTaskInfo({
-            taskId: data.taskId,
-            removeOnFinish: false,
-          });
-
-          return taskInfo;
+  private async updateTask(task: AsyncTask, data: WsAsyncTaskInfo) {
+    if (data.running === false) {
+      await task.updateInfoAsync(async () => {
+        const { taskInfo } = await this.graphQLService.sdk.getAsyncTaskInfo({
+          taskId: data.taskId,
+          removeOnFinish: false,
         });
-      } else {
-        task?.updateStatus(data);
-      }
-    });
+
+        return taskInfo;
+      });
+    } else {
+      task.updateStatus(data);
+    }
+  }
+
+  private async handleEvent(data: WsAsyncTaskInfo) {
+    const task = this.getTask(data.taskId);
+
+    if (!task) {
+      this.pendingEvents.set(data.taskId, data);
+      return;
+    }
+
+    await this.updateTask(task, data);
   }
 
   override dispose(): void {
@@ -56,9 +70,18 @@ export class AsyncTaskInfoService extends Disposable {
 
   create(getter: () => Promise<AsyncTaskInfo>): AsyncTask {
     const task = new AsyncTask(getter, this.cancelTask.bind(this));
+
     this.tasks.set(task.id, task);
     task.onStatusChange.addHandler(info => {
-      this.taskIdAliases.set(info.id, task.id);
+      const pendingEvent = this.pendingEvents.get(info.id);
+      if (pendingEvent) {
+        const changes = { ...pendingEvent };
+        this.pendingEvents.delete(info.id);
+        this.updateTask(task, changes);
+      }
+      if (!this.taskIdAliases.get(info.id)) {
+        this.taskIdAliases.set(info.id, task.id);
+      }
     });
 
     if (this.tasks.size === 1) {
@@ -103,6 +126,7 @@ export class AsyncTaskInfoService extends Disposable {
     this.tasks.delete(task.id);
     if (task.info) {
       this.taskIdAliases.delete(task.info.id);
+      this.pendingEvents.delete(task.info.id);
     }
     if (this.tasks.size === 0) {
       this.connection?.unsubscribe();

--- a/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
+++ b/webapp/packages/core-root/src/AsyncTask/AsyncTaskInfoService.ts
@@ -5,20 +5,49 @@
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
  */
-import { injectable } from '@cloudbeaver/core-di';
-import { type AsyncTaskInfo, GraphQLService } from '@cloudbeaver/core-sdk';
-import { cancellableTimeout } from '@cloudbeaver/core-utils';
+import type { Subscription } from 'rxjs';
 
+import { Disposable, injectable } from '@cloudbeaver/core-di';
+import { type AsyncTaskInfo, GraphQLService, type WsAsyncTaskInfo } from '@cloudbeaver/core-sdk';
+
+import { ServerEventId } from '../SessionEventSource.js';
 import { AsyncTask } from './AsyncTask.js';
-
-const DELAY_BETWEEN_TRIES = 250;
+import { AsyncTaskInfoEventHandler } from './AsyncTaskInfoEventHandler.js';
 
 @injectable()
-export class AsyncTaskInfoService {
+export class AsyncTaskInfoService extends Disposable {
   private readonly tasks: Map<string, AsyncTask>;
+  private connection: Subscription | null;
+  private onEvent: any;
 
-  constructor(private readonly graphQLService: GraphQLService) {
+  constructor(
+    private readonly graphQLService: GraphQLService,
+    private readonly asyncTaskInfoEventHandler: AsyncTaskInfoEventHandler,
+  ) {
+    super();
     this.tasks = new Map();
+    this.connection = null;
+
+    this.onEvent = asyncTaskInfoEventHandler.onEvent<WsAsyncTaskInfo>(ServerEventId.CbSessionTaskInfoUpdated, async data => {
+      console.log('onEvent', data);
+      // const task = this.tasks.get(data.taskId);
+
+      // if (task?.pending && task.info) {
+      //   await task.updateInfoAsync(async task => {
+      //     const { taskInfo } = await this.graphQLService.sdk.getAsyncTaskInfo({
+      //       taskId: task.info!.id,
+      //       removeOnFinish: false,
+      //     });
+
+      //     return taskInfo;
+      //   });
+      // }
+    });
+  }
+
+  override dispose(): void {
+    this.connection?.unsubscribe();
+    this.onEvent.dispose();
   }
 
   create(getter: () => Promise<AsyncTaskInfo>): AsyncTask {
@@ -26,7 +55,7 @@ export class AsyncTaskInfoService {
     this.tasks.set(task.id, task);
 
     if (this.tasks.size === 1) {
-      setTimeout(() => this.update(), 1);
+      this.connection = this.asyncTaskInfoEventHandler.eventsSubject.connect();
     }
 
     return task;
@@ -53,6 +82,11 @@ export class AsyncTaskInfoService {
 
     this.tasks.delete(taskId);
 
+    if (this.tasks.size === 0) {
+      this.connection?.unsubscribe();
+      this.connection = null;
+    }
+
     if (task.info !== null) {
       await this.graphQLService.sdk.getAsyncTaskInfo({
         taskId: task.info.id,
@@ -65,35 +99,6 @@ export class AsyncTaskInfoService {
     const task = this.tasks.get(taskId);
 
     await task?.cancelAsync();
-  }
-
-  private async update() {
-    while (this.tasks.size > 0) {
-      const tasks = Array.from(this.tasks.values());
-
-      for (const task of tasks) {
-        this.updateTask(task);
-      }
-
-      await cancellableTimeout(DELAY_BETWEEN_TRIES);
-    }
-  }
-
-  private async updateTask(task: AsyncTask): Promise<void> {
-    try {
-      if (task.pending && task.info) {
-        await task.updateInfoAsync(async task => {
-          const { taskInfo } = await this.graphQLService.sdk.getAsyncTaskInfo({
-            taskId: task.info!.id,
-            removeOnFinish: false,
-          });
-
-          return taskInfo;
-        });
-      }
-    } catch (e: any) {
-      console.log('Failed to check async task status', e);
-    }
   }
 
   private async cancelTask(info: AsyncTaskInfo): Promise<void> {

--- a/webapp/packages/core-root/src/ServerEventEmitter/IServerEventEmitter.ts
+++ b/webapp/packages/core-root/src/ServerEventEmitter/IServerEventEmitter.ts
@@ -10,7 +10,7 @@ import type { Observable } from 'rxjs';
 import type { ISyncExecutor } from '@cloudbeaver/core-executor';
 
 export type IServerEventCallback<T> = (data: T) => any;
-export type Subscription = () => void;
+export type Unsubscribe = () => void;
 
 export interface IBaseServerEvent<TID extends string = string, TTopic extends string = string> {
   id: TID;
@@ -25,9 +25,9 @@ export interface IServerEventEmitter<
 > {
   readonly onInit: ISyncExecutor;
 
-  onEvent<T = TEvent>(id: TEventID, callback: IServerEventCallback<T>, mapTo?: (event: TEvent) => T): Subscription;
+  onEvent<T = TEvent>(id: TEventID, callback: IServerEventCallback<T>, mapTo?: (event: TEvent) => T): Unsubscribe;
 
-  on<T = TEvent>(callback: IServerEventCallback<T>, mapTo?: (event: TEvent) => T, filter?: (event: TEvent) => boolean): Subscription;
+  on<T = TEvent>(callback: IServerEventCallback<T>, mapTo?: (event: TEvent) => T, filter?: (event: TEvent) => boolean): Unsubscribe;
 
   multiplex<T = TEvent>(topicId: TTopic, mapTo?: (event: TEvent) => T): Observable<T>;
 

--- a/webapp/packages/core-root/src/SessionEventSource.ts
+++ b/webapp/packages/core-root/src/SessionEventSource.ts
@@ -35,7 +35,7 @@ import {
 } from '@cloudbeaver/core-sdk';
 
 import { NetworkStateService } from './NetworkStateService.js';
-import type { IBaseServerEvent, IServerEventCallback, IServerEventEmitter, Subscription } from './ServerEventEmitter/IServerEventEmitter.js';
+import type { IBaseServerEvent, IServerEventCallback, IServerEventEmitter, Unsubscribe } from './ServerEventEmitter/IServerEventEmitter.js';
 import { SessionExpireService } from './SessionExpireService.js';
 
 export { ServerEventId, SessionEventTopic, ClientEventId };
@@ -111,7 +111,7 @@ export class SessionEventSource implements IServerEventEmitter<ISessionEvent, IS
     this.errorHandler = this.errorHandler.bind(this);
   }
 
-  onEvent<T = ISessionEvent>(id: SessionEventId, callback: IServerEventCallback<T>, mapTo: (event: ISessionEvent) => T = e => e as T): Subscription {
+  onEvent<T = ISessionEvent>(id: SessionEventId, callback: IServerEventCallback<T>, mapTo: (event: ISessionEvent) => T = e => e as T): Unsubscribe {
     const sub = this.eventsSubject
       .pipe(
         filter(event => event.id === id),
@@ -128,7 +128,7 @@ export class SessionEventSource implements IServerEventEmitter<ISessionEvent, IS
     callback: IServerEventCallback<T>,
     mapTo: (event: ISessionEvent) => T = e => e as T,
     filterFn: (event: ISessionEvent) => boolean = () => true,
-  ): Subscription {
+  ): Unsubscribe {
     const sub = this.eventsSubject.pipe(filter(filterFn), map(mapTo)).subscribe(callback);
 
     return () => {

--- a/webapp/packages/core-root/src/index.ts
+++ b/webapp/packages/core-root/src/index.ts
@@ -37,4 +37,6 @@ export * from './ServerNodeService.js';
 export * from './ServerResourceQuotasResource.js';
 export * from './WindowEventsService.js';
 export * from './ServerLicenseStatusResource.js';
+export * from './AsyncTask/AsyncTask.js';
+export * from './AsyncTask/AsyncTaskInfoService.js';
 export * from './manifest.js';

--- a/webapp/packages/core-root/src/manifest.ts
+++ b/webapp/packages/core-root/src/manifest.ts
@@ -13,6 +13,7 @@ export const coreRootManifest: PluginManifest = {
   },
 
   providers: [
+    () => import('./AsyncTask/AsyncTaskInfoService.js').then(m => m.AsyncTaskInfoService),
     () => import('./FeaturesResource.js').then(m => m.FeaturesResource),
     () => import('./NetworkStateService.js').then(m => m.NetworkStateService),
     () => import('./SessionPermissionsResource.js').then(m => m.SessionPermissionsResource),

--- a/webapp/packages/core-root/src/manifest.ts
+++ b/webapp/packages/core-root/src/manifest.ts
@@ -14,6 +14,7 @@ export const coreRootManifest: PluginManifest = {
 
   providers: [
     () => import('./AsyncTask/AsyncTaskInfoService.js').then(m => m.AsyncTaskInfoService),
+    () => import('./AsyncTask/AsyncTaskInfoEventHandler.js').then(m => m.AsyncTaskInfoEventHandler),
     () => import('./FeaturesResource.js').then(m => m.FeaturesResource),
     () => import('./NetworkStateService.js').then(m => m.NetworkStateService),
     () => import('./SessionPermissionsResource.js').then(m => m.SessionPermissionsResource),

--- a/webapp/packages/core-sdk/src/index.ts
+++ b/webapp/packages/core-sdk/src/index.ts
@@ -5,8 +5,6 @@
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
  */
-export * from './AsyncTask/AsyncTask.js';
-export * from './AsyncTask/AsyncTaskInfoService.js';
 export * from './Extensions/uploadBlobResultSetExtension.js';
 export * from './CustomGraphQLClient.js';
 export * from './DetailsError.js';

--- a/webapp/packages/core-sdk/src/manifest.ts
+++ b/webapp/packages/core-sdk/src/manifest.ts
@@ -13,7 +13,6 @@ export const coreSDKManifest: PluginManifest = {
   },
 
   providers: [
-    () => import('./AsyncTask/AsyncTaskInfoService.js').then(m => m.AsyncTaskInfoService),
     () => import('./EnvironmentService.js').then(m => m.EnvironmentService),
     () => import('./GraphQLService.js').then(m => m.GraphQLService),
   ],

--- a/webapp/packages/plugin-app-logo-administration/tsconfig.json
+++ b/webapp/packages/plugin-app-logo-administration/tsconfig.json
@@ -19,6 +19,16 @@
       "path": "../plugin-app-logo/tsconfig.json"
     }
   ],
-  "include": ["__custom_mocks__/**/*", "src/**/*", "src/**/*.json", "src/**/*.css", "src/**/*.scss"],
-  "exclude": ["**/node_modules", "lib/**/*", "dist/**/*"]
+  "include": [
+    "__custom_mocks__/**/*",
+    "src/**/*",
+    "src/**/*.json",
+    "src/**/*.css",
+    "src/**/*.scss"
+  ],
+  "exclude": [
+    "**/node_modules",
+    "lib/**/*",
+    "dist/**/*"
+  ]
 }

--- a/webapp/packages/plugin-data-import/src/DataImportService.ts
+++ b/webapp/packages/plugin-data-import/src/DataImportService.ts
@@ -10,7 +10,7 @@ import { computed, makeObservable } from 'mobx';
 import { ProcessSnackbar } from '@cloudbeaver/core-blocks';
 import { injectable } from '@cloudbeaver/core-di';
 import { NotificationService } from '@cloudbeaver/core-events';
-import { type AsyncTaskInfoService, EAdminPermission, SessionPermissionsResource } from '@cloudbeaver/core-root';
+import { AsyncTaskInfoService, EAdminPermission, SessionPermissionsResource } from '@cloudbeaver/core-root';
 import { GraphQLService } from '@cloudbeaver/core-sdk';
 import { getProgressPercent } from '@cloudbeaver/core-utils';
 

--- a/webapp/packages/plugin-data-import/src/DataImportService.ts
+++ b/webapp/packages/plugin-data-import/src/DataImportService.ts
@@ -10,8 +10,8 @@ import { computed, makeObservable } from 'mobx';
 import { ProcessSnackbar } from '@cloudbeaver/core-blocks';
 import { injectable } from '@cloudbeaver/core-di';
 import { NotificationService } from '@cloudbeaver/core-events';
-import { EAdminPermission, SessionPermissionsResource } from '@cloudbeaver/core-root';
-import { AsyncTaskInfoService, GraphQLService } from '@cloudbeaver/core-sdk';
+import { type AsyncTaskInfoService, EAdminPermission, SessionPermissionsResource } from '@cloudbeaver/core-root';
+import { GraphQLService } from '@cloudbeaver/core-sdk';
 import { getProgressPercent } from '@cloudbeaver/core-utils';
 
 import { DataImportSettingsService } from './DataImportSettingsService.js';

--- a/webapp/packages/plugin-data-viewer-result-set-grouping/package.json
+++ b/webapp/packages/plugin-data-viewer-result-set-grouping/package.json
@@ -24,6 +24,7 @@
     "@cloudbeaver/core-di": "^0",
     "@cloudbeaver/core-dialogs": "^0",
     "@cloudbeaver/core-localization": "^0",
+    "@cloudbeaver/core-root": "^0",
     "@cloudbeaver/core-sdk": "^0",
     "@cloudbeaver/core-ui": "^0",
     "@cloudbeaver/core-utils": "^0",

--- a/webapp/packages/plugin-data-viewer-result-set-grouping/src/useGroupingDataModel.ts
+++ b/webapp/packages/plugin-data-viewer-result-set-grouping/src/useGroupingDataModel.ts
@@ -11,7 +11,8 @@ import { useEffect } from 'react';
 import { useObjectRef, useResource } from '@cloudbeaver/core-blocks';
 import { ConnectionInfoResource, createConnectionParam } from '@cloudbeaver/core-connections';
 import { IServiceProvider, useService } from '@cloudbeaver/core-di';
-import { AsyncTaskInfoService, GraphQLService } from '@cloudbeaver/core-sdk';
+import { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { GraphQLService } from '@cloudbeaver/core-sdk';
 import { isObjectsEqual } from '@cloudbeaver/core-utils';
 import {
   DatabaseDataAccessMode,

--- a/webapp/packages/plugin-data-viewer/src/ContainerDataSource.ts
+++ b/webapp/packages/plugin-data-viewer/src/ContainerDataSource.ts
@@ -10,9 +10,8 @@ import { computed, makeObservable, observable } from 'mobx';
 import type { ConnectionExecutionContextService, IConnectionExecutionContext, IConnectionExecutionContextInfo } from '@cloudbeaver/core-connections';
 import type { IServiceProvider } from '@cloudbeaver/core-di';
 import type { ITask } from '@cloudbeaver/core-executor';
+import type { AsyncTask, AsyncTaskInfoService } from '@cloudbeaver/core-root';
 import {
-  AsyncTask,
-  AsyncTaskInfoService,
   GraphQLService,
   ResultDataFormat,
   type SqlExecuteInfo,

--- a/webapp/packages/plugin-data-viewer/src/DataViewerTableService.ts
+++ b/webapp/packages/plugin-data-viewer/src/DataViewerTableService.ts
@@ -8,7 +8,8 @@
 import { type Connection, ConnectionExecutionContextService, createConnectionParam } from '@cloudbeaver/core-connections';
 import { injectable, IServiceProvider } from '@cloudbeaver/core-di';
 import { EObjectFeature, type NavNode, NavNodeManagerService } from '@cloudbeaver/core-navigation-tree';
-import { AsyncTaskInfoService, GraphQLService } from '@cloudbeaver/core-sdk';
+import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { GraphQLService } from '@cloudbeaver/core-sdk';
 
 import { ContainerDataSource } from './ContainerDataSource.js';
 import { DatabaseDataModel } from './DatabaseDataModel/DatabaseDataModel.js';

--- a/webapp/packages/plugin-data-viewer/src/DataViewerTableService.ts
+++ b/webapp/packages/plugin-data-viewer/src/DataViewerTableService.ts
@@ -8,7 +8,7 @@
 import { type Connection, ConnectionExecutionContextService, createConnectionParam } from '@cloudbeaver/core-connections';
 import { injectable, IServiceProvider } from '@cloudbeaver/core-di';
 import { EObjectFeature, type NavNode, NavNodeManagerService } from '@cloudbeaver/core-navigation-tree';
-import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { AsyncTaskInfoService } from '@cloudbeaver/core-root';
 import { GraphQLService } from '@cloudbeaver/core-sdk';
 
 import { ContainerDataSource } from './ContainerDataSource.js';

--- a/webapp/packages/plugin-data-viewer/src/ResultSet/ResultSetDataSource.ts
+++ b/webapp/packages/plugin-data-viewer/src/ResultSet/ResultSetDataSource.ts
@@ -10,7 +10,8 @@ import { makeObservable, observable } from 'mobx';
 import type { IConnectionExecutionContext, IConnectionExecutionContextInfo } from '@cloudbeaver/core-connections';
 import type { IServiceProvider } from '@cloudbeaver/core-di';
 import type { ITask } from '@cloudbeaver/core-executor';
-import type { AsyncTaskInfoService, GraphQLService } from '@cloudbeaver/core-sdk';
+import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import type { GraphQLService } from '@cloudbeaver/core-sdk';
 
 import { DatabaseDataSource } from '../DatabaseDataModel/DatabaseDataSource.js';
 import { type IDatabaseDataOptions } from '../DatabaseDataModel/IDatabaseDataOptions.js';

--- a/webapp/packages/plugin-data-viewer/src/ResultSet/ResultSetDataSource.ts
+++ b/webapp/packages/plugin-data-viewer/src/ResultSet/ResultSetDataSource.ts
@@ -10,7 +10,7 @@ import { makeObservable, observable } from 'mobx';
 import type { IConnectionExecutionContext, IConnectionExecutionContextInfo } from '@cloudbeaver/core-connections';
 import type { IServiceProvider } from '@cloudbeaver/core-di';
 import type { ITask } from '@cloudbeaver/core-executor';
-import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { AsyncTaskInfoService } from '@cloudbeaver/core-root';
 import type { GraphQLService } from '@cloudbeaver/core-sdk';
 
 import { DatabaseDataSource } from '../DatabaseDataModel/DatabaseDataSource.js';

--- a/webapp/packages/plugin-sql-editor/src/QueryDataSource.ts
+++ b/webapp/packages/plugin-sql-editor/src/QueryDataSource.ts
@@ -10,7 +10,7 @@ import { makeObservable, observable } from 'mobx';
 import type { IConnectionExecutionContextInfo } from '@cloudbeaver/core-connections';
 import type { IServiceProvider } from '@cloudbeaver/core-di';
 import type { ITask } from '@cloudbeaver/core-executor';
-import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { AsyncTaskInfoService } from '@cloudbeaver/core-root';
 import {
   GraphQLService,
   ResultDataFormat,

--- a/webapp/packages/plugin-sql-editor/src/QueryDataSource.ts
+++ b/webapp/packages/plugin-sql-editor/src/QueryDataSource.ts
@@ -10,8 +10,8 @@ import { makeObservable, observable } from 'mobx';
 import type { IConnectionExecutionContextInfo } from '@cloudbeaver/core-connections';
 import type { IServiceProvider } from '@cloudbeaver/core-di';
 import type { ITask } from '@cloudbeaver/core-executor';
+import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
 import {
-  AsyncTaskInfoService,
   GraphQLService,
   ResultDataFormat,
   type SqlExecuteInfo,

--- a/webapp/packages/plugin-sql-editor/src/SqlResultTabs/ExecutionPlan/SqlExecutionPlanService.ts
+++ b/webapp/packages/plugin-sql-editor/src/SqlResultTabs/ExecutionPlan/SqlExecutionPlanService.ts
@@ -11,7 +11,8 @@ import { ConnectionExecutionContextService } from '@cloudbeaver/core-connections
 import { injectable } from '@cloudbeaver/core-di';
 import { NotificationService } from '@cloudbeaver/core-events';
 import type { ITask } from '@cloudbeaver/core-executor';
-import { AsyncTaskInfoService, GraphQLService, type SqlExecutionPlan } from '@cloudbeaver/core-sdk';
+import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { GraphQLService, type SqlExecutionPlan } from '@cloudbeaver/core-sdk';
 import { uuid } from '@cloudbeaver/core-utils';
 
 import type { ISqlEditorTabState } from '../../ISqlEditorTabState.js';

--- a/webapp/packages/plugin-sql-editor/src/SqlResultTabs/ExecutionPlan/SqlExecutionPlanService.ts
+++ b/webapp/packages/plugin-sql-editor/src/SqlResultTabs/ExecutionPlan/SqlExecutionPlanService.ts
@@ -11,7 +11,7 @@ import { ConnectionExecutionContextService } from '@cloudbeaver/core-connections
 import { injectable } from '@cloudbeaver/core-di';
 import { NotificationService } from '@cloudbeaver/core-events';
 import type { ITask } from '@cloudbeaver/core-executor';
-import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { AsyncTaskInfoService } from '@cloudbeaver/core-root';
 import { GraphQLService, type SqlExecutionPlan } from '@cloudbeaver/core-sdk';
 import { uuid } from '@cloudbeaver/core-utils';
 

--- a/webapp/packages/plugin-sql-editor/src/SqlResultTabs/SqlQueryService.ts
+++ b/webapp/packages/plugin-sql-editor/src/SqlResultTabs/SqlQueryService.ts
@@ -10,7 +10,7 @@ import { makeObservable, observable } from 'mobx';
 import { ConnectionExecutionContextService, ConnectionInfoResource, createConnectionParam } from '@cloudbeaver/core-connections';
 import { injectable, IServiceProvider } from '@cloudbeaver/core-di';
 import { NotificationService } from '@cloudbeaver/core-events';
-import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { AsyncTaskInfoService } from '@cloudbeaver/core-root';
 import { GraphQLService } from '@cloudbeaver/core-sdk';
 import {
   DatabaseDataAccessMode,

--- a/webapp/packages/plugin-sql-editor/src/SqlResultTabs/SqlQueryService.ts
+++ b/webapp/packages/plugin-sql-editor/src/SqlResultTabs/SqlQueryService.ts
@@ -10,7 +10,8 @@ import { makeObservable, observable } from 'mobx';
 import { ConnectionExecutionContextService, ConnectionInfoResource, createConnectionParam } from '@cloudbeaver/core-connections';
 import { injectable, IServiceProvider } from '@cloudbeaver/core-di';
 import { NotificationService } from '@cloudbeaver/core-events';
-import { AsyncTaskInfoService, GraphQLService } from '@cloudbeaver/core-sdk';
+import type { AsyncTaskInfoService } from '@cloudbeaver/core-root';
+import { GraphQLService } from '@cloudbeaver/core-sdk';
 import {
   DatabaseDataAccessMode,
   DatabaseDataModel,


### PR DESCRIPTION
1. `AsyncTaskService` was moved to core-root to avoid circular dependencies
2. Task is added to tasks map only when getter brings data from backend to save real task ID (`AsyncTask.create`)
3. `updateStatus` method was added to update task status on websocket message if task is running
4. When `running` prop is changing to `false`, we request gql endpoint
5. Naming improvements (onEvent  return type Subscription -> Unsubscribe) to avoid confusion with Rx Subscription plus it's basically returns cancel function, not subscription in any sense.