### PR TITLE
CB-5999 fix: don't see changes when change connection view

### DIFF
--- a/webapp/packages/plugin-connections/src/ContextMenu/ConnectionMenuBootstrap.ts
+++ b/webapp/packages/plugin-connections/src/ContextMenu/ConnectionMenuBootstrap.ts
@@ -243,7 +243,7 @@ export class ConnectionMenuBootstrap extends Bootstrap {
       connection = await this.connectionInfoResource.changeConnectionView(createConnectionParam(connection), settings);
 
       if (connection.nodePath) {
-        await this.navNodeManagerService.refreshNode(connection.nodePath);
+        await this.navNodeManagerService.refreshTree(connection.nodePath);
       }
     } catch (exception: any) {
       this.notificationService.logException(exception);


### PR DESCRIPTION
The root of this problem for flat files connections is in the fact that on the top level of a connection, we get the same node when change connection view. That's why we don't go deeper, when use refreshNode and children remain their previous state. I didn't find a way to detect this case somehow based on results of queries, so I just used refreshTree method for changing connection view, which updates all the children. 


https://github.com/user-attachments/assets/55705dd9-6b7d-492e-8891-f3e0b0471d50

