### PR TITLE
[DO NOT MERGE] 68 UI poc

### DIFF
--- a/webapp/packages/core-app/src/Body.module.css
+++ b/webapp/packages/core-app/src/Body.module.css
@@ -12,6 +12,7 @@
   padding: 0 !important;
   flex-direction: column;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .loader {

--- a/webapp/packages/core-app/src/Body.tsx
+++ b/webapp/packages/core-app/src/Body.tsx
@@ -59,6 +59,7 @@ export const Body = observer(function Body() {
             'theme-typography--body2',
             'theme-background-surface',
             'theme-text-on-surface',
+            'root',
           )}
         >
           <Loader className={s(styles, { loader: true })} suspense>

--- a/webapp/packages/core-blocks/package.json
+++ b/webapp/packages/core-blocks/package.json
@@ -19,6 +19,7 @@
     "update-ts-references": "yarn run clean && typescript-resolve-references"
   },
   "dependencies": {
+    "@ariakit/react": "^0.4.15",
     "@base-ui-components/react": "^1.0.0-alpha.5",
     "@cloudbeaver/core-authentication": "^0",
     "@cloudbeaver/core-di": "^0",

--- a/webapp/packages/core-blocks/package.json
+++ b/webapp/packages/core-blocks/package.json
@@ -31,6 +31,8 @@
     "@cloudbeaver/core-sdk": "^0",
     "@cloudbeaver/core-theming": "^0",
     "@cloudbeaver/core-utils": "^0",
+    "@mantine/core": "^7.16.1",
+    "@mantine/hooks": "^7.16.1",
     "go-split": "^3",
     "mobx": "^6",
     "mobx-react-lite": "^4",

--- a/webapp/packages/core-blocks/package.json
+++ b/webapp/packages/core-blocks/package.json
@@ -19,6 +19,7 @@
     "update-ts-references": "yarn run clean && typescript-resolve-references"
   },
   "dependencies": {
+    "@base-ui-components/react": "^1.0.0-alpha.5",
     "@cloudbeaver/core-authentication": "^0",
     "@cloudbeaver/core-di": "^0",
     "@cloudbeaver/core-dialogs": "^0",

--- a/webapp/packages/core-blocks/src/AriaKitPopover/AriaKitPopover.module.css
+++ b/webapp/packages/core-blocks/src/AriaKitPopover/AriaKitPopover.module.css
@@ -1,0 +1,148 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+.button {
+  --border: rgb(0 0 0/13%);
+  --highlight: rgb(255 255 255/20%);
+  --shadow: rgb(0 0 0/10%);
+  display: flex;
+  height: 2.5rem;
+  user-select: none;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  white-space: nowrap;
+  border-radius: 0.5rem;
+  border-style: none;
+  background-color: white;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: black;
+  text-decoration-line: none;
+  outline-width: 2px;
+  outline-offset: 2px;
+  outline-color: hsl(204 100% 40%);
+  box-shadow:
+    inset 0 0 0 1px var(--border),
+    inset 0 2px 0 var(--highlight),
+    inset 0 -1px 0 var(--shadow),
+    0 1px 1px var(--shadow);
+  font-weight: 500;
+}
+
+.button:where(.dark, .dark *) {
+  --border: rgb(255 255 255/10%);
+  --highlight: rgb(255 255 255/5%);
+  --shadow: rgb(0 0 0/25%);
+  background-color: rgb(255 255 255 / 0.05);
+  color: white;
+  box-shadow:
+    inset 0 0 0 1px var(--border),
+    inset 0 -1px 0 1px var(--shadow),
+    inset 0 1px 0 var(--highlight);
+}
+
+.button:not(:active):hover {
+  --border: rgb(0 0 0/33%);
+}
+
+.button:where(.dark, .dark *):not(:active):hover {
+  --border: rgb(255 255 255/25%);
+}
+
+.button[aria-disabled='true'] {
+  opacity: 0.5;
+}
+
+.button[data-focus-visible] {
+  outline-style: solid;
+}
+
+.button:active,
+.button[data-active] {
+  padding-top: 0.125rem;
+  box-shadow:
+    inset 0 0 0 1px var(--border),
+    inset 0 2px 0 var(--border);
+}
+
+@media (min-width: 640px) {
+  .button {
+    gap: 0.5rem;
+  }
+}
+
+.button:active:where(.dark, .dark *),
+.button[data-active]:where(.dark, .dark *) {
+  box-shadow:
+    inset 0 0 0 1px var(--border),
+    inset 0 1px 1px 1px var(--shadow);
+}
+
+.popover {
+  z-index: 50;
+  display: flex;
+  max-width: min(calc(100vw - 16px), 320px);
+  flex-direction: column;
+  gap: 1rem;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-style: solid;
+  border-color: hsl(204 20% 88%);
+  background-color: white;
+  padding: 1rem;
+  color: black;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.1),
+    0 4px 6px -4px rgb(0 0 0 / 0.1);
+}
+
+.popover:focus-visible,
+.popover[data-focus-visible] {
+  outline: 2px solid hsl(204 100% 40%);
+  outline-offset: 2px;
+}
+
+.popover:where(.dark, .dark *) {
+  border-color: hsl(204 4% 24%);
+  background-color: hsl(204 4% 16%);
+  color: white;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.25),
+    0 4px 6px -4px rgb(0 0 0 / 0.1);
+}
+
+.arrow > svg {
+  fill: white;
+  stroke: hsl(204 20% 88%);
+}
+
+.arrow:where(.dark, .dark *) > svg {
+  fill: hsl(204 4% 16%);
+  stroke: hsl(204 4% 24%);
+}
+
+.heading {
+  margin: 0px;
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  font-weight: 500;
+}
+
+.spinner {
+  height: 1rem;
+  width: 1rem;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/webapp/packages/core-blocks/src/AriaKitPopover/AriaKitPopover.tsx
+++ b/webapp/packages/core-blocks/src/AriaKitPopover/AriaKitPopover.tsx
@@ -1,0 +1,43 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+import * as Ariakit from '@ariakit/react';
+import styles from 'AriaKitPopover.module.css';
+import { lazy, useState, useTransition } from 'react';
+
+const Popover = lazy(() => import('./Popover.js'));
+
+export function AriaKitPopover({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [_, startTransition] = useTransition();
+
+  return (
+    <Ariakit.PopoverProvider
+      open={open}
+      setOpen={open => {
+        if (open) {
+          return startTransition(() => setOpen(open));
+        }
+        setOpen(open);
+      }}
+    >
+      <Ariakit.PopoverDisclosure>{children}</Ariakit.PopoverDisclosure>
+      {open && (
+        <Popover className={styles['popover']}>
+          <Ariakit.PopoverArrow className={styles['arrow']} />
+          <Ariakit.PopoverHeading className={styles['heading']}>Team meeting</Ariakit.PopoverHeading>
+          <Ariakit.PopoverDescription>We are going to discuss what we have achieved on the project.</Ariakit.PopoverDescription>
+          <div>
+            <p>12 Jan 2022 18:00 to 19:00</p>
+            <p>Alert 10 minutes before start</p>
+          </div>
+          <Ariakit.Button className={styles['button']}>Accept</Ariakit.Button>
+        </Popover>
+      )}
+    </Ariakit.PopoverProvider>
+  );
+}

--- a/webapp/packages/core-blocks/src/AriaKitPopover/Popover.ts
+++ b/webapp/packages/core-blocks/src/AriaKitPopover/Popover.ts
@@ -1,0 +1,8 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+export { Popover as default } from '@ariakit/react';

--- a/webapp/packages/core-blocks/src/BasePopover/BasePopover.module.css
+++ b/webapp/packages/core-blocks/src/BasePopover/BasePopover.module.css
@@ -1,0 +1,101 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+.iconButton {
+  background-color: transparent;
+  &:active {
+    background-color: aqua;
+  }
+}
+
+.icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.popup {
+  box-sizing: border-box;
+  padding: 1rem 1.5rem;
+  border-radius: 0.5rem;
+  background-color: canvas;
+  color: gray;
+  transform-origin: --transform-origin;
+  transition:
+    transform 150ms,
+    opacity 150ms;
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+
+  @media (prefers-color-scheme: light) {
+    outline: 1px solid lightgray;
+    box-shadow:
+      0px 10px 15px -3px lightgray,
+      0px 4px 6px -4px lightgray;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    outline: 1px solid lightgray;
+    outline-offset: -1px;
+  }
+}
+
+.arrow {
+  display: flex;
+
+  &[data-side='top'] {
+    bottom: -8px;
+    rotate: 180deg;
+  }
+  &[data-side='bottom'] {
+    top: -8px;
+    rotate: 0deg;
+  }
+  &[data-side='left'] {
+    right: -13px;
+    rotate: 90deg;
+  }
+  &[data-side='right'] {
+    left: -13px;
+    rotate: -90deg;
+  }
+}
+
+.arrowFill {
+  fill: canvas;
+}
+
+.arrowOuterStroke {
+  fill: lightgray;
+}
+
+.arrowInnerStroke {
+  fill: lightgray;
+}
+
+.title {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 500;
+}
+
+.description {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: gray;
+}
+
+.actions {
+  display: flex;
+  justify-content: end;
+  gap: 1rem;
+}

--- a/webapp/packages/core-blocks/src/BasePopover/BasePopover.module.css
+++ b/webapp/packages/core-blocks/src/BasePopover/BasePopover.module.css
@@ -8,7 +8,7 @@
 .iconButton {
   background-color: transparent;
   &:active {
-    background-color: aqua;
+    background-color: gainsboro;
   }
 }
 

--- a/webapp/packages/core-blocks/src/BasePopover/BasePopover.tsx
+++ b/webapp/packages/core-blocks/src/BasePopover/BasePopover.tsx
@@ -1,0 +1,50 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+import { Popover } from '@base-ui-components/react/popover';
+import * as React from 'react';
+
+import { s } from '../s.js';
+import styles from './BasePopover.module.css';
+
+export function BasePopover({ children }: { children: React.ReactNode }) {
+  return (
+    <Popover.Root>
+      <Popover.Trigger className={s(styles, { iconButton: true })}>{children}</Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner sideOffset={8}>
+          <Popover.Popup className={s(styles, { popup: true })}>
+            <Popover.Arrow className={s(styles, { arrow: true })}>
+              <ArrowSvg />
+            </Popover.Arrow>
+            <Popover.Title className={s(styles, { title: true })}>Notifications</Popover.Title>
+            <Popover.Description className={s(styles, { description: true })}>You are all caught up. Good job!</Popover.Description>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+function ArrowSvg(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg width="20" height="10" viewBox="0 0 20 10" fill="none" {...props}>
+      <path
+        d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
+        className={s(styles, { arrowFill: true })}
+      />
+      <path
+        d="M8.99542 1.85876C9.75604 1.17425 10.9106 1.17422 11.6713 1.85878L16.5281 6.22989C17.0789 6.72568 17.7938 7.00001 18.5349 7.00001L15.89 7L11.0023 2.60207C10.622 2.2598 10.0447 2.2598 9.66436 2.60207L4.77734 7L2.13171 7.00001C2.87284 7.00001 3.58774 6.72568 4.13861 6.22989L8.99542 1.85876Z"
+        className={s(styles, { arrowOuterStroke: true })}
+      />
+      <path
+        d="M10.3333 3.34539L5.47654 7.71648C4.55842 8.54279 3.36693 9 2.13172 9H0V8H2.13172C3.11989 8 4.07308 7.63423 4.80758 6.97318L9.66437 2.60207C10.0447 2.25979 10.622 2.2598 11.0023 2.60207L15.8591 6.97318C16.5936 7.63423 17.5468 8 18.5349 8H20V9H18.5349C17.2998 9 16.1083 8.54278 15.1901 7.71648L10.3333 3.34539Z"
+        className={s(styles, { arrowInnerStroke: true })}
+      />
+    </svg>
+  );
+}

--- a/webapp/packages/core-blocks/src/FormControls/Checkboxes/AriaKitSwitch.module.css
+++ b/webapp/packages/core-blocks/src/FormControls/Checkboxes/AriaKitSwitch.module.css
@@ -1,0 +1,76 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+.switchWrapper {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.switch {
+  position: relative;
+  display: flex;
+  align-items: center;
+  appearance: none;
+  border: 0;
+  margin: 0;
+  padding: 1px;
+  width: 2.5rem !important;
+  height: 1.5rem !important;
+  border-radius: 1.5rem;
+  outline: 1px solid;
+  outline-offset: -1px;
+  background-color: transparent;
+  background-image: linear-gradient(to right, gray 35%, lightgray 65%);
+  background-size: 6.5rem 100%;
+  background-position-x: 100%;
+  background-repeat: no-repeat;
+  transition-property: background-position, box-shadow;
+  transition-timing-function: cubic-bezier(0.26, 0.75, 0.38, 0.45);
+  transition-duration: 125ms;
+
+  &:active {
+    background-color: lightblue;
+  }
+
+  &[data-checked='true'] {
+    background-position-x: 0%;
+  }
+
+  &[data-checked='true']:active {
+    background-color: lightslategray;
+  }
+
+  &:focus-visible {
+    &::before {
+      content: '';
+      inset: 0;
+      position: absolute;
+      border-radius: inherit;
+      outline: 2px solid var(--color-blue);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.thumb {
+  padding: 0.25rem;
+  width: 1rem !important;
+  height: 1rem !important;
+  aspect-ratio: 1 / 1;
+  height: 100%;
+  border-radius: 100%;
+  background-color: white;
+  transition: translate 150ms ease;
+
+  &[data-checked='true'] {
+    translate: 1rem 0;
+  }
+}
+
+.title {
+  margin-inline-start: 1rem;
+}

--- a/webapp/packages/core-blocks/src/FormControls/Checkboxes/AriaKitSwitch.tsx
+++ b/webapp/packages/core-blocks/src/FormControls/Checkboxes/AriaKitSwitch.tsx
@@ -18,7 +18,7 @@ export const AriaKitSwitch = forwardRef<HTMLInputElement, CheckboxProps>(functio
   const [checked, setChecked] = useState(props.defaultChecked ?? false);
   const [focusVisible, setFocusVisible] = useState(false);
   return (
-    <label className={styles.switchWrapper} data-checked={checked} data-focus-visible={focusVisible || undefined}>
+    <label className={styles['switchWrapper']} data-checked={checked} data-focus-visible={focusVisible || undefined}>
       <Ariakit.VisuallyHidden>
         <Ariakit.Checkbox
           {...props}
@@ -32,10 +32,10 @@ export const AriaKitSwitch = forwardRef<HTMLInputElement, CheckboxProps>(functio
           }}
         />
       </Ariakit.VisuallyHidden>
-      <div className={styles.switch} data-checked={checked}>
-        <div className={styles.thumb} data-checked={checked} />
+      <div className={styles['switch']} data-checked={checked}>
+        <div className={styles['thumb']} data-checked={checked} />
       </div>
-      <span className={styles.title}> {children}</span>
+      <span className={styles['title']}> {children}</span>
     </label>
   );
 });

--- a/webapp/packages/core-blocks/src/FormControls/Checkboxes/AriaKitSwitch.tsx
+++ b/webapp/packages/core-blocks/src/FormControls/Checkboxes/AriaKitSwitch.tsx
@@ -1,0 +1,41 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+import * as Ariakit from '@ariakit/react';
+import { type ComponentPropsWithoutRef, forwardRef, type ReactNode, useState } from 'react';
+
+import styles from './AriaKitSwitch.module.css';
+
+interface CheckboxProps extends ComponentPropsWithoutRef<'input'> {
+  children?: ReactNode;
+}
+
+export const AriaKitSwitch = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox({ children, ...props }, ref) {
+  const [checked, setChecked] = useState(props.defaultChecked ?? false);
+  const [focusVisible, setFocusVisible] = useState(false);
+  return (
+    <label className={styles.switchWrapper} data-checked={checked} data-focus-visible={focusVisible || undefined}>
+      <Ariakit.VisuallyHidden>
+        <Ariakit.Checkbox
+          {...props}
+          ref={ref}
+          clickOnEnter
+          onFocusVisible={() => setFocusVisible(true)}
+          onBlur={() => setFocusVisible(false)}
+          onChange={event => {
+            setChecked(event.target.checked);
+            props.onChange?.(event);
+          }}
+        />
+      </Ariakit.VisuallyHidden>
+      <div className={styles.switch} data-checked={checked}>
+        <div className={styles.thumb} data-checked={checked} />
+      </div>
+      <span className={styles.title}> {children}</span>
+    </label>
+  );
+});

--- a/webapp/packages/core-blocks/src/FormControls/Checkboxes/BaseSwitch.module.css
+++ b/webapp/packages/core-blocks/src/FormControls/Checkboxes/BaseSwitch.module.css
@@ -1,0 +1,73 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+.switchWrapper {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.switch {
+  position: relative;
+  display: flex;
+  align-items: center;
+  appearance: none;
+  border: 0;
+  margin: 0;
+  padding: 1px;
+  width: 2.5rem !important;
+  height: 1.5rem !important;
+  border-radius: 1.5rem;
+  outline: 1px solid;
+  outline-offset: -1px;
+  background-color: transparent;
+  background-image: linear-gradient(to right, gray 35%, lightgray 65%);
+  background-size: 6.5rem 100%;
+  background-position-x: 100%;
+  background-repeat: no-repeat;
+  transition-property: background-position, box-shadow;
+  transition-timing-function: cubic-bezier(0.26, 0.75, 0.38, 0.45);
+  transition-duration: 125ms;
+
+  &:active {
+    background-color: lightblue;
+  }
+
+  &[data-checked] {
+    background-position-x: 0%;
+  }
+
+  &[data-checked]:active {
+    background-color: lightslategray;
+  }
+
+  &:focus-visible {
+    &::before {
+      content: '';
+      inset: 0;
+      position: absolute;
+      border-radius: inherit;
+      outline: 2px solid var(--color-blue);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.thumb {
+  aspect-ratio: 1 / 1;
+  height: 100%;
+  border-radius: 100%;
+  background-color: white;
+  transition: translate 150ms ease;
+
+  &[data-checked] {
+    translate: 1rem 0;
+  }
+}
+
+.title {
+  margin-inline-start: 1rem;
+}

--- a/webapp/packages/core-blocks/src/FormControls/Checkboxes/BaseSwitch.tsx
+++ b/webapp/packages/core-blocks/src/FormControls/Checkboxes/BaseSwitch.tsx
@@ -16,7 +16,9 @@ export const BaseSwitch = observer(function BaseSwitch(props: Switch.Root.Props)
       <Switch.Root className={styles.switch} {...props}>
         <Switch.Thumb className={styles.thumb} />
       </Switch.Root>
-      <span className={styles.title}> {props.children}</span>
+      <label htmlFor={props.id} className={styles.title}>
+        {props.children}
+      </label>
     </div>
   );
 });

--- a/webapp/packages/core-blocks/src/FormControls/Checkboxes/BaseSwitch.tsx
+++ b/webapp/packages/core-blocks/src/FormControls/Checkboxes/BaseSwitch.tsx
@@ -1,0 +1,22 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+import { Switch } from '@base-ui-components/react/switch';
+import { observer } from 'mobx-react-lite';
+
+import styles from './BaseSwitch.module.css';
+
+export const BaseSwitch = observer(function BaseSwitch(props: Switch.Root.Props) {
+  return (
+    <div className={styles.switchWrapper}>
+      <Switch.Root className={styles.switch} {...props}>
+        <Switch.Thumb className={styles.thumb} />
+      </Switch.Root>
+      <span className={styles.title}> {props.children}</span>
+    </div>
+  );
+});

--- a/webapp/packages/core-blocks/src/FormControls/Checkboxes/BaseSwitch.tsx
+++ b/webapp/packages/core-blocks/src/FormControls/Checkboxes/BaseSwitch.tsx
@@ -12,11 +12,11 @@ import styles from './BaseSwitch.module.css';
 
 export const BaseSwitch = observer(function BaseSwitch(props: Switch.Root.Props) {
   return (
-    <div className={styles.switchWrapper}>
-      <Switch.Root className={styles.switch} {...props}>
-        <Switch.Thumb className={styles.thumb} />
+    <div className={styles['switchWrapper']}>
+      <Switch.Root className={styles['switch']} {...props}>
+        <Switch.Thumb className={styles['thumb']} />
       </Switch.Root>
-      <label htmlFor={props.id} className={styles.title}>
+      <label htmlFor={props.id} className={styles['title']}>
         {props.children}
       </label>
     </div>

--- a/webapp/packages/core-blocks/src/FormControls/Checkboxes/MantineSwitch.module.css
+++ b/webapp/packages/core-blocks/src/FormControls/Checkboxes/MantineSwitch.module.css
@@ -6,11 +6,26 @@
  * you may not use this file except in compliance with the License.
  */
 .switchWrapper {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
+  label {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  input {
+    display: none;
+  }
+
+  &[data-checked] .thumb {
+    translate: 1rem 0;
+  }
+
+  &[data-checked] .track {
+    background-image: linear-gradient(to right, gray 35%, black 65%);
+  }
 }
-.switch {
+
+.track {
   position: relative;
   display: flex;
   align-items: center;
@@ -18,7 +33,7 @@
   border: 0;
   margin: 0;
   padding: 1px;
-  width: 3.6rem !important;
+  width: 2.5rem !important;
   height: 1.5rem !important;
   border-radius: 1.5rem;
   outline: 1px solid;
@@ -31,29 +46,6 @@
   transition-property: background-position, box-shadow;
   transition-timing-function: cubic-bezier(0.26, 0.75, 0.38, 0.45);
   transition-duration: 125ms;
-
-  &:active {
-    background-color: lightblue;
-  }
-
-  &[data-checked] {
-    background-position-x: 0%;
-  }
-
-  &[data-checked]:active {
-    background-color: lightslategray;
-  }
-
-  &:focus-visible {
-    &::before {
-      content: '';
-      inset: 0;
-      position: absolute;
-      border-radius: inherit;
-      outline: 2px solid var(--color-blue);
-      outline-offset: 2px;
-    }
-  }
 }
 
 .thumb {
@@ -62,10 +54,12 @@
   border-radius: 100%;
   background-color: white;
   transition: translate 150ms ease;
+}
 
-  &[data-checked] {
-    translate: 1rem 0;
-  }
+.labelWrapper {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .title {

--- a/webapp/packages/core-blocks/src/FormControls/Checkboxes/MantineSwitch.tsx
+++ b/webapp/packages/core-blocks/src/FormControls/Checkboxes/MantineSwitch.tsx
@@ -1,0 +1,19 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+import { Switch, type SwitchProps } from '@mantine/core';
+
+import styles from './MantineSwitch.module.css';
+
+export function MantineSwitch(props: SwitchProps) {
+  return (
+    <Switch
+      classNames={{ root: styles.switchWrapper, track: styles.track, thumb: styles.thumb, labelWrapper: styles.labelWrapper, label: styles.title }}
+      {...props}
+    />
+  );
+}

--- a/webapp/packages/core-blocks/src/FormControls/Checkboxes/MantineSwitch.tsx
+++ b/webapp/packages/core-blocks/src/FormControls/Checkboxes/MantineSwitch.tsx
@@ -12,7 +12,13 @@ import styles from './MantineSwitch.module.css';
 export function MantineSwitch(props: SwitchProps) {
   return (
     <Switch
-      classNames={{ root: styles.switchWrapper, track: styles.track, thumb: styles.thumb, labelWrapper: styles.labelWrapper, label: styles.title }}
+      classNames={{
+        root: styles['switchWrapper'],
+        track: styles['track'],
+        thumb: styles['thumb'],
+        labelWrapper: styles['labelWrapper'],
+        label: styles['title'],
+      }}
       {...props}
     />
   );

--- a/webapp/packages/core-blocks/src/MantinePopover.module.css
+++ b/webapp/packages/core-blocks/src/MantinePopover.module.css
@@ -1,0 +1,25 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+
+.popover {
+  z-index: 50;
+  display: flex;
+  max-width: min(calc(100vw - 16px), 320px);
+  flex-direction: column;
+  gap: 1rem;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-style: solid;
+  border-color: hsl(204 20% 88%);
+  background-color: white;
+  padding: 1rem;
+  color: black;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.1),
+    0 4px 6px -4px rgb(0 0 0 / 0.1);
+}

--- a/webapp/packages/core-blocks/src/MantinePopover.tsx
+++ b/webapp/packages/core-blocks/src/MantinePopover.tsx
@@ -1,0 +1,20 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2024 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+import { Popover } from '@mantine/core';
+import type { PropsWithChildren } from 'react';
+
+import styles from './MantinePopover.module.css';
+
+export function MantinePopover({ children }: PropsWithChildren) {
+  return (
+    <Popover classNames={{ dropdown: styles['popover'] }} width={200} position="bottom">
+      <Popover.Target>{children}</Popover.Target>
+      <Popover.Dropdown>This is uncontrolled popover, it is opened when button is clicked</Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/webapp/packages/core-blocks/src/index.ts
+++ b/webapp/packages/core-blocks/src/index.ts
@@ -254,3 +254,4 @@ export * from './importLazyComponent.js';
 export * from './ClickableLoader.js';
 export * from './FormControls/TagsComboboxLoader.js';
 export * from './Flex/Flex.js';
+export * from './BasePopover/BasePopover.js';

--- a/webapp/packages/core-blocks/src/index.ts
+++ b/webapp/packages/core-blocks/src/index.ts
@@ -7,6 +7,7 @@
  */
 export { useHotkeys } from 'react-hotkeys-hook';
 
+export * from './AriaKitPopover/AriaKitPopover.js';
 export * from './CommonDialog/CommonDialog/CommonDialogBody.js';
 export * from './CommonDialog/CommonDialog/CommonDialogFooter.js';
 export * from './CommonDialog/CommonDialog/CommonDialogHeader.js';

--- a/webapp/packages/core-blocks/src/index.ts
+++ b/webapp/packages/core-blocks/src/index.ts
@@ -8,6 +8,7 @@
 export { useHotkeys } from 'react-hotkeys-hook';
 
 export * from './AriaKitPopover/AriaKitPopover.js';
+export * from './MantinePopover.js';
 export * from './CommonDialog/CommonDialog/CommonDialogBody.js';
 export * from './CommonDialog/CommonDialog/CommonDialogFooter.js';
 export * from './CommonDialog/CommonDialog/CommonDialogHeader.js';

--- a/webapp/packages/core-blocks/src/index.ts
+++ b/webapp/packages/core-blocks/src/index.ts
@@ -151,6 +151,7 @@ export * from './FormControls/Checkboxes/CheckboxMarkup.js';
 export * from './FormControls/Checkboxes/Switch.js';
 export * from './FormControls/Checkboxes/BaseSwitch.js';
 export * from './FormControls/Checkboxes/MantineSwitch.js';
+export * from './FormControls/Checkboxes/AriaKitSwitch.js';
 export * from './FormControls/Checkboxes/useCheckboxState.js';
 export * from './FormControls/Filter.js';
 export { default as BaseDropdownStyles } from './FormControls/BaseDropdown.module.css';

--- a/webapp/packages/core-blocks/src/index.ts
+++ b/webapp/packages/core-blocks/src/index.ts
@@ -148,6 +148,7 @@ export * from './FormControls/Checkboxes/Checkbox.js';
 export * from './FormControls/Checkboxes/FieldCheckbox.js';
 export * from './FormControls/Checkboxes/CheckboxMarkup.js';
 export * from './FormControls/Checkboxes/Switch.js';
+export * from './FormControls/Checkboxes/BaseSwitch.js';
 export * from './FormControls/Checkboxes/useCheckboxState.js';
 export * from './FormControls/Filter.js';
 export { default as BaseDropdownStyles } from './FormControls/BaseDropdown.module.css';

--- a/webapp/packages/core-blocks/src/index.ts
+++ b/webapp/packages/core-blocks/src/index.ts
@@ -149,6 +149,7 @@ export * from './FormControls/Checkboxes/FieldCheckbox.js';
 export * from './FormControls/Checkboxes/CheckboxMarkup.js';
 export * from './FormControls/Checkboxes/Switch.js';
 export * from './FormControls/Checkboxes/BaseSwitch.js';
+export * from './FormControls/Checkboxes/MantineSwitch.js';
 export * from './FormControls/Checkboxes/useCheckboxState.js';
 export * from './FormControls/Filter.js';
 export { default as BaseDropdownStyles } from './FormControls/BaseDropdown.module.css';

--- a/webapp/packages/core-bootstrap/package.json
+++ b/webapp/packages/core-bootstrap/package.json
@@ -53,6 +53,7 @@
     "@cloudbeaver/core-version": "^0",
     "@cloudbeaver/core-version-update": "^0",
     "@cloudbeaver/core-view": "^0",
+    "@mantine/core": "^7.16.1",
     "mobx": "^6",
     "react": "^18",
     "react-dom": "^18"

--- a/webapp/packages/core-bootstrap/src/renderLayout.tsx
+++ b/webapp/packages/core-bootstrap/src/renderLayout.tsx
@@ -5,6 +5,7 @@
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
  */
+import { HeadlessMantineProvider } from '@mantine/core';
 import { Suspense } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
@@ -51,8 +52,10 @@ export function renderLayout(serviceProvider: IServiceProvider): IRender {
           <ServiceProviderContext serviceProvider={serviceProvider}>
             <ErrorBoundary fallback={<HideAppLoadingScreen />} root>
               <Suspense fallback={<Loader className={s(styles, { loader: true })} />}>
-                <BodyLazy />
-                <HideAppLoadingScreen />
+                <HeadlessMantineProvider>
+                  <BodyLazy />
+                  <HideAppLoadingScreen />
+                </HeadlessMantineProvider>
               </Suspense>
             </ErrorBoundary>
           </ServiceProviderContext>

--- a/webapp/packages/plugin-help/src/Shortcuts/ShortcutsDialog.tsx
+++ b/webapp/packages/plugin-help/src/Shortcuts/ShortcutsDialog.tsx
@@ -6,6 +6,7 @@
  * you may not use this file except in compliance with the License.
  */
 import {
+  BasePopover,
   Button,
   CommonDialogBody,
   CommonDialogFooter,
@@ -32,7 +33,9 @@ export const ShortcutsDialog: DialogComponent<null> = function ShortcutsDialog({
 
   return (
     <CommonDialogWrapper size="large">
-      <CommonDialogHeader title={translate('shortcuts_title')} onReject={rejectDialog} />
+      <BasePopover>
+        <CommonDialogHeader title={translate('shortcuts_title')} onReject={rejectDialog} />
+      </BasePopover>
       <CommonDialogBody>
         <Container className={s(styles, { container: true })} gap wrap overflow>
           <Group box gap dense overflow>

--- a/webapp/packages/plugin-help/src/Shortcuts/ShortcutsDialog.tsx
+++ b/webapp/packages/plugin-help/src/Shortcuts/ShortcutsDialog.tsx
@@ -6,6 +6,7 @@
  * you may not use this file except in compliance with the License.
  */
 import {
+  AriaKitPopover,
   BasePopover,
   Button,
   CommonDialogBody,
@@ -36,6 +37,9 @@ export const ShortcutsDialog: DialogComponent<null> = function ShortcutsDialog({
       <BasePopover>
         <CommonDialogHeader title={translate('shortcuts_title')} onReject={rejectDialog} />
       </BasePopover>
+      <AriaKitPopover>
+        <CommonDialogHeader title={translate('shortcuts_title')} onReject={rejectDialog} />
+      </AriaKitPopover>
       <CommonDialogBody>
         <Container className={s(styles, { container: true })} gap wrap overflow>
           <Group box gap dense overflow>

--- a/webapp/packages/plugin-help/src/Shortcuts/ShortcutsDialog.tsx
+++ b/webapp/packages/plugin-help/src/Shortcuts/ShortcutsDialog.tsx
@@ -17,6 +17,7 @@ import {
   Group,
   GroupTitle,
   Link,
+  MantinePopover,
   s,
   useS,
   useTranslate,
@@ -40,6 +41,10 @@ export const ShortcutsDialog: DialogComponent<null> = function ShortcutsDialog({
       <AriaKitPopover>
         <CommonDialogHeader title={translate('shortcuts_title')} onReject={rejectDialog} />
       </AriaKitPopover>
+      <MantinePopover>
+        <button>123</button>
+      </MantinePopover>
+
       <CommonDialogBody>
         <Container className={s(styles, { container: true })} gap wrap overflow>
           <Group box gap dense overflow>

--- a/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/ElementsTreeTools/NavigationTreeSettings/ElementsTreeBaseSettingsForm.tsx
+++ b/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/ElementsTreeTools/NavigationTreeSettings/ElementsTreeBaseSettingsForm.tsx
@@ -8,7 +8,7 @@
 import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
 
-import { BaseSwitch, GroupTitle, type PlaceholderComponent, Switch, useTranslate } from '@cloudbeaver/core-blocks';
+import { BaseSwitch, GroupTitle, MantineSwitch, type PlaceholderComponent, Switch, useTranslate } from '@cloudbeaver/core-blocks';
 
 import type { IElementsTreeSettingsProps } from './ElementsTreeSettingsService.js';
 
@@ -22,6 +22,10 @@ export const ElementsTreeBaseSettingsForm: PlaceholderComponent<IElementsTreeSet
     return null;
   }
 
+  function onFilterChange() {
+    setFilterState(prev => !prev);
+  }
+
   return (
     <>
       <GroupTitle>{translate('ui_settings')}</GroupTitle>
@@ -31,10 +35,11 @@ export const ElementsTreeBaseSettingsForm: PlaceholderComponent<IElementsTreeSet
         checked={filterState}
         disabled={!settings.configurable}
         title={translate('app_navigationTree_settings_filter_description')}
-        onCheckedChange={setFilterState}
+        onCheckedChange={onFilterChange}
       >
         {translate('app_navigationTree_settings_filter_title')}
       </BaseSwitch>
+      <MantineSwitch checked={filterState} label={translate('app_navigationTree_settings_filter_title')} onChange={onFilterChange} />
       <Switch
         id={`${root}.filterAll`}
         name="filterAll"

--- a/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/ElementsTreeTools/NavigationTreeSettings/ElementsTreeBaseSettingsForm.tsx
+++ b/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/ElementsTreeTools/NavigationTreeSettings/ElementsTreeBaseSettingsForm.tsx
@@ -6,14 +6,16 @@
  * you may not use this file except in compliance with the License.
  */
 import { observer } from 'mobx-react-lite';
+import { useState } from 'react';
 
-import { GroupTitle, type PlaceholderComponent, Switch, useTranslate } from '@cloudbeaver/core-blocks';
+import { BaseSwitch, GroupTitle, type PlaceholderComponent, Switch, useTranslate } from '@cloudbeaver/core-blocks';
 
 import type { IElementsTreeSettingsProps } from './ElementsTreeSettingsService.js';
 
 export const ElementsTreeBaseSettingsForm: PlaceholderComponent<IElementsTreeSettingsProps> = observer(function ElementsTreeBaseSettingsForm({
   tree: { root, settings },
 }) {
+  const [filterState, setFilterState] = useState(true);
   const translate = useTranslate();
 
   if (!settings) {
@@ -23,17 +25,16 @@ export const ElementsTreeBaseSettingsForm: PlaceholderComponent<IElementsTreeSet
   return (
     <>
       <GroupTitle>{translate('ui_settings')}</GroupTitle>
-      <Switch
+      <BaseSwitch
         id={`${root}.filter`}
         name="filter"
-        state={settings}
+        checked={filterState}
         disabled={!settings.configurable}
         title={translate('app_navigationTree_settings_filter_description')}
-        mod={['primary', 'dense']}
-        small
+        onCheckedChange={setFilterState}
       >
         {translate('app_navigationTree_settings_filter_title')}
-      </Switch>
+      </BaseSwitch>
       <Switch
         id={`${root}.filterAll`}
         name="filterAll"

--- a/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/ElementsTreeTools/NavigationTreeSettings/ElementsTreeBaseSettingsForm.tsx
+++ b/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/ElementsTreeTools/NavigationTreeSettings/ElementsTreeBaseSettingsForm.tsx
@@ -8,7 +8,7 @@
 import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
 
-import { BaseSwitch, GroupTitle, MantineSwitch, type PlaceholderComponent, Switch, useTranslate } from '@cloudbeaver/core-blocks';
+import { AriaKitSwitch, BaseSwitch, GroupTitle, MantineSwitch, type PlaceholderComponent, Switch, useTranslate } from '@cloudbeaver/core-blocks';
 
 import type { IElementsTreeSettingsProps } from './ElementsTreeSettingsService.js';
 
@@ -39,6 +39,7 @@ export const ElementsTreeBaseSettingsForm: PlaceholderComponent<IElementsTreeSet
       >
         {translate('app_navigationTree_settings_filter_title')}
       </BaseSwitch>
+      <AriaKitSwitch> Filter </AriaKitSwitch>
       <MantineSwitch checked={filterState} label={translate('app_navigationTree_settings_filter_title')} onChange={onFilterChange} />
       <Switch
         id={`${root}.filterAll`}

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -1015,7 +1015,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.23.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.23.2", "@babel/runtime@^7.26.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
   integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
@@ -1075,6 +1075,18 @@
   dependencies:
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
+
+"@base-ui-components/react@^1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@base-ui-components/react/-/react-1.0.0-alpha.5.tgz#dd69ec6e6acfd64cac0e016ae5370a7b0668354c"
+  integrity sha512-/hkuXkfiuMZpX1rp1alx2QAah7dUnojgUxtmbEjxYaeS7xiifw9N645ek8e3Dd3QPhVYmDZYfqj/aYUS0IwIqA==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@floating-ui/react" "^0.27.3"
+    "@floating-ui/utils" "^0.2.9"
+    "@react-aria/overlays" "^3.24.0"
+    prop-types "^15.8.1"
+    use-sync-external-store "^1.4.0"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -1731,10 +1743,87 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.9.tgz#64d1da251433019dafa091de9b2886ff35ec14e6"
+  integrity sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==
+  dependencies:
+    "@floating-ui/utils" "^0.2.9"
+
+"@floating-ui/dom@^1.0.0":
+  version "1.6.13"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.13.tgz#a8a938532aea27a95121ec16e667a7cbe8c59e34"
+  integrity sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.9"
+
+"@floating-ui/react-dom@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.2.tgz#a1349bbf6a0e5cb5ded55d023766f20a4d439a31"
+  integrity sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
+"@floating-ui/react@^0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.27.3.tgz#f9a30583eddd5770f3a6e1f3479a258f3df0c8c8"
+  integrity sha512-CLHnes3ixIFFKVQDdICjel8muhFLOBdQH7fgtHNPY8UbCNqbeKZ262G7K66lGQOUQWWnYocf7ZbUsLJgGfsLHg==
+  dependencies:
+    "@floating-ui/react-dom" "^2.1.2"
+    "@floating-ui/utils" "^0.2.9"
+    tabbable "^6.0.0"
+
+"@floating-ui/utils@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
+  integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
+
 "@fontsource/roboto@^5":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-5.1.0.tgz#00230737ec09c60ae877a5e33d067c0607fdd5ba"
   integrity sha512-cFRRC1s6RqPygeZ8Uw/acwVHqih8Czjt6Q0MwoUoDe9U3m4dH1HmNDRBZyqlMSFwgNAUKgFImncKdmDHyKpwdg==
+
+"@formatjs/ecma402-abstract@2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.2.tgz#0ee291effe7ee2c340742a6c95d92eacb5e6c00a"
+  integrity sha512-6sE5nyvDloULiyOMbOTJEEgWL32w+VHkZQs8S02Lnn8Y/O5aQhjOEXwWzvR7SsBE/exxlSpY2EsWZgqHbtLatg==
+  dependencies:
+    "@formatjs/fast-memoize" "2.2.6"
+    "@formatjs/intl-localematcher" "0.5.10"
+    decimal.js "10"
+    tslib "2"
+
+"@formatjs/fast-memoize@2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-2.2.6.tgz#fac0a84207a1396be1f1aa4ee2805b179e9343d1"
+  integrity sha512-luIXeE2LJbQnnzotY1f2U2m7xuQNj2DA8Vq4ce1BY9ebRZaoPB1+8eZ6nXpLzsxuW5spQxr7LdCg+CApZwkqkw==
+  dependencies:
+    tslib "2"
+
+"@formatjs/icu-messageformat-parser@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.0.tgz#28d22a735114b7309c0d3e43d39f2660917867c8"
+  integrity sha512-Hp81uTjjdTk3FLh/dggU5NK7EIsVWc5/ZDWrIldmf2rBuPejuZ13CZ/wpVE2SToyi4EiroPTQ1XJcJuZFIxTtw==
+  dependencies:
+    "@formatjs/ecma402-abstract" "2.3.2"
+    "@formatjs/icu-skeleton-parser" "1.8.12"
+    tslib "2"
+
+"@formatjs/icu-skeleton-parser@1.8.12":
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.12.tgz#43076747cdbe0f23bfac2b2a956bd8219716680d"
+  integrity sha512-QRAY2jC1BomFQHYDMcZtClqHR55EEnB96V7Xbk/UiBodsuFc5kujybzt87+qj1KqmJozFhk6n4KiT1HKwAkcfg==
+  dependencies:
+    "@formatjs/ecma402-abstract" "2.3.2"
+    tslib "2"
+
+"@formatjs/intl-localematcher@0.5.10":
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz#1e0bd3fc1332c1fe4540cfa28f07e9227b659a58"
+  integrity sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==
+  dependencies:
+    tslib "2"
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -2342,6 +2431,35 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-3.0.1.tgz#619ce9f65c3e114d8e39c41822bed3440d20b478"
   integrity sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==
+
+"@internationalized/date@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@internationalized/date/-/date-3.7.0.tgz#23a4956308ee108e308517a7137c69ab8f5f2ad9"
+  integrity sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@internationalized/message@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@internationalized/message/-/message-3.1.6.tgz#e5a832788a17214bfb3e5bbf5f0e23ed2f568ad7"
+  integrity sha512-JxbK3iAcTIeNr1p0WIFg/wQJjIzJt9l/2KNY/48vXV7GRGZSv3zMxJsce008fZclk2cDC8y0Ig3odceHO7EfNQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+    intl-messageformat "^10.1.0"
+
+"@internationalized/number@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@internationalized/number/-/number-3.6.0.tgz#dc6ba20c41b25eb605f1d5cac7d8668e9022c224"
+  integrity sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@internationalized/string@^3.2.5":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@internationalized/string/-/string-3.2.5.tgz#2f387b256e79596a2e62ddd5e15c619fe241189c"
+  integrity sha512-rKs71Zvl2OKOHM+mzAFMIyqR5hI1d1O6BBkMK2/lkfg3fkmVh9Eeg0awcA8W2WqYqDOv6a86DIOlFpggwLtbuw==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
 
 "@inversifyjs/common@1.4.0":
   version "1.4.0"
@@ -4052,6 +4170,86 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
+"@react-aria/focus@^3.19.1":
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.19.1.tgz#6655e53d04eb7b46c8d39e671013d1c17fca5ba2"
+  integrity sha512-bix9Bu1Ue7RPcYmjwcjhB14BMu2qzfJ3tMQLqDc9pweJA66nOw8DThy3IfVr8Z7j2PHktOLf9kcbiZpydKHqzg==
+  dependencies:
+    "@react-aria/interactions" "^3.23.0"
+    "@react-aria/utils" "^3.27.0"
+    "@react-types/shared" "^3.27.0"
+    "@swc/helpers" "^0.5.0"
+    clsx "^2.0.0"
+
+"@react-aria/i18n@^3.12.5":
+  version "3.12.5"
+  resolved "https://registry.yarnpkg.com/@react-aria/i18n/-/i18n-3.12.5.tgz#7dc2ab8bbf2374c1797e3c553f34735be88f52eb"
+  integrity sha512-ooeop2pTG94PuaHoN2OTk2hpkqVuoqgEYxRvnc1t7DVAtsskfhS/gVOTqyWGsxvwAvRi7m/CnDu6FYdeQ/bK5w==
+  dependencies:
+    "@internationalized/date" "^3.7.0"
+    "@internationalized/message" "^3.1.6"
+    "@internationalized/number" "^3.6.0"
+    "@internationalized/string" "^3.2.5"
+    "@react-aria/ssr" "^3.9.7"
+    "@react-aria/utils" "^3.27.0"
+    "@react-types/shared" "^3.27.0"
+    "@swc/helpers" "^0.5.0"
+
+"@react-aria/interactions@^3.23.0":
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.23.0.tgz#28fce22310faeaa114978728045fb2b4fe80acc8"
+  integrity sha512-0qR1atBIWrb7FzQ+Tmr3s8uH5mQdyRH78n0krYaG8tng9+u1JlSi8DGRSaC9ezKyNB84m7vHT207xnHXGeJ3Fg==
+  dependencies:
+    "@react-aria/ssr" "^3.9.7"
+    "@react-aria/utils" "^3.27.0"
+    "@react-types/shared" "^3.27.0"
+    "@swc/helpers" "^0.5.0"
+
+"@react-aria/overlays@^3.24.0":
+  version "3.25.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/overlays/-/overlays-3.25.0.tgz#794c4f2f08ea6ccdd18b3030776b3929a4950cdb"
+  integrity sha512-UEqJJ4duowrD1JvwXpPZreBuK79pbyNjNxFUVpFSskpGEJe3oCWwsSDKz7P1O7xbx5OYp+rDiY8fk/sE5rkaKw==
+  dependencies:
+    "@react-aria/focus" "^3.19.1"
+    "@react-aria/i18n" "^3.12.5"
+    "@react-aria/interactions" "^3.23.0"
+    "@react-aria/ssr" "^3.9.7"
+    "@react-aria/utils" "^3.27.0"
+    "@react-aria/visually-hidden" "^3.8.19"
+    "@react-stately/overlays" "^3.6.13"
+    "@react-types/button" "^3.10.2"
+    "@react-types/overlays" "^3.8.12"
+    "@react-types/shared" "^3.27.0"
+    "@swc/helpers" "^0.5.0"
+
+"@react-aria/ssr@^3.9.7":
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.9.7.tgz#d89d129f7bbc5148657e6c952ac31c9353183770"
+  integrity sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@react-aria/utils@^3.27.0":
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.27.0.tgz#92a58177c60055bb007c2e886d2d914f42df2386"
+  integrity sha512-p681OtApnKOdbeN8ITfnnYqfdHS0z7GE+4l8EXlfLnr70Rp/9xicBO6d2rU+V/B3JujDw2gPWxYKEnEeh0CGCw==
+  dependencies:
+    "@react-aria/ssr" "^3.9.7"
+    "@react-stately/utils" "^3.10.5"
+    "@react-types/shared" "^3.27.0"
+    "@swc/helpers" "^0.5.0"
+    clsx "^2.0.0"
+
+"@react-aria/visually-hidden@^3.8.19":
+  version "3.8.19"
+  resolved "https://registry.yarnpkg.com/@react-aria/visually-hidden/-/visually-hidden-3.8.19.tgz#4717f6d4333dfa901fa1805c289a025ca0e9dbfc"
+  integrity sha512-MZgCCyQ3sdG94J5iJz7I7Ai3IxoN0U5d/+EaUnA1mfK7jf2fSYQBqi6Eyp8sWUYzBTLw4giXB5h0RGAnWzk9hA==
+  dependencies:
+    "@react-aria/interactions" "^3.23.0"
+    "@react-aria/utils" "^3.27.0"
+    "@react-types/shared" "^3.27.0"
+    "@swc/helpers" "^0.5.0"
+
 "@react-dnd/asap@^5.0.1":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-5.0.2.tgz#1f81f124c1cd6f39511c11a881cfb0f715343488"
@@ -4071,6 +4269,41 @@
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@react-leaflet/core/-/core-2.1.0.tgz#383acd31259d7c9ae8fb1b02d5e18fe613c2a13d"
   integrity sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==
+
+"@react-stately/overlays@^3.6.13":
+  version "3.6.13"
+  resolved "https://registry.yarnpkg.com/@react-stately/overlays/-/overlays-3.6.13.tgz#37cd757d3404d0fb827216a8e11dbce8ea2186c7"
+  integrity sha512-WsU85Gf/b+HbWsnnYw7P/Ila3wD+C37Uk/WbU4/fHgJ26IEOWsPE6wlul8j54NZ1PnLNhV9Fn+Kffi+PaJMQXQ==
+  dependencies:
+    "@react-stately/utils" "^3.10.5"
+    "@react-types/overlays" "^3.8.12"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/utils@^3.10.5":
+  version "3.10.5"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.10.5.tgz#47bb91cd5afd1bafe39353614e5e281b818ebccc"
+  integrity sha512-iMQSGcpaecghDIh3mZEpZfoFH3ExBwTtuBEcvZ2XnGzCgQjeYXcMdIUwAfVQLXFTdHUHGF6Gu6/dFrYsCzySBQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@react-types/button@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@react-types/button/-/button-3.10.2.tgz#60ce0d4a16690d94a8ae23bb00207c8af9616919"
+  integrity sha512-h8SB/BLoCgoBulCpyzaoZ+miKXrolK9XC48+n1dKJXT8g4gImrficurDW6+PRTQWaRai0Q0A6bu8UibZOU4syg==
+  dependencies:
+    "@react-types/shared" "^3.27.0"
+
+"@react-types/overlays@^3.8.12":
+  version "3.8.12"
+  resolved "https://registry.yarnpkg.com/@react-types/overlays/-/overlays-3.8.12.tgz#0cd1ee17e6eacc33899821ab34045fc396898c22"
+  integrity sha512-ZvR1t0YV7/6j+6OD8VozKYjvsXT92+C/2LOIKozy7YUNS5KI4MkXbRZzJvkuRECVZOmx8JXKTUzhghWJM/3QuQ==
+  dependencies:
+    "@react-types/shared" "^3.27.0"
+
+"@react-types/shared@^3.27.0":
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.27.0.tgz#167c163139efc98c2194aba090076c03b658c07d"
+  integrity sha512-gvznmLhi6JPEf0bsq7SwRYTHAKKq/wcmKqFez9sRdbED+SPMUmK5omfZ6w3EwUFQHbYUa4zPBYedQ7Knv70RMw==
 
 "@repeaterjs/repeater@^3.0.4", "@repeaterjs/repeater@^3.0.6":
   version "3.0.6"
@@ -4253,6 +4486,13 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
   integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
+
+"@swc/helpers@^0.5.0":
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.15.tgz#79efab344c5819ecf83a43f3f9f811fc84b516d7"
+  integrity sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==
+  dependencies:
+    tslib "^2.8.0"
 
 "@swc/jest@^0":
   version "0.2.37"
@@ -7427,7 +7667,7 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
-decimal.js@^10.4.2:
+decimal.js@10, decimal.js@^10.4.2:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
@@ -9828,6 +10068,16 @@ interpret@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-3.1.1.tgz#5be0ceed67ca79c6c4bc5cf0d7ee843dcea110c4"
   integrity sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==
+
+intl-messageformat@^10.1.0:
+  version "10.7.14"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-10.7.14.tgz#ddcbbfdb1682afe56da094f21a4ac74fc3c91552"
+  integrity sha512-mMGnE4E1otdEutV5vLUdCxRJygHB5ozUBxsPB5qhitewssrS/qGruq9bmvIRkkGsNeK5ZWLfYRld18UHGTIifQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "2.3.2"
+    "@formatjs/fast-memoize" "2.2.6"
+    "@formatjs/icu-messageformat-parser" "2.11.0"
+    tslib "2"
 
 invariant@^2.2.4:
   version "2.2.4"
@@ -15153,6 +15403,11 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+tabbable@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
+  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
+
 tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
@@ -15459,15 +15714,15 @@ tsconfig-paths@^4.1.2, tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tslib@2, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.3, tslib@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.3:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@~2.4.0:
   version "2.4.1"
@@ -15875,6 +16130,11 @@ use-sync-external-store@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
   integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
+
+use-sync-external-store@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
+  integrity sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -1015,7 +1015,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.23.2", "@babel/runtime@^7.26.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.20.13", "@babel/runtime@^7.23.2", "@babel/runtime@^7.26.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
   integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
@@ -1765,6 +1765,15 @@
   dependencies:
     "@floating-ui/dom" "^1.0.0"
 
+"@floating-ui/react@^0.26.28":
+  version "0.26.28"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.26.28.tgz#93f44ebaeb02409312e9df9507e83aab4a8c0dc7"
+  integrity sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==
+  dependencies:
+    "@floating-ui/react-dom" "^2.1.2"
+    "@floating-ui/utils" "^0.2.8"
+    tabbable "^6.0.0"
+
 "@floating-ui/react@^0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.27.3.tgz#f9a30583eddd5770f3a6e1f3479a258f3df0c8c8"
@@ -1774,7 +1783,7 @@
     "@floating-ui/utils" "^0.2.9"
     tabbable "^6.0.0"
 
-"@floating-ui/utils@^0.2.9":
+"@floating-ui/utils@^0.2.8", "@floating-ui/utils@^0.2.9":
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
   integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
@@ -3528,6 +3537,23 @@
     "@lezer/common" "^1.2.0"
     "@lezer/highlight" "^1.0.0"
     "@lezer/lr" "^1.0.0"
+
+"@mantine/core@^7.16.1":
+  version "7.16.1"
+  resolved "https://registry.yarnpkg.com/@mantine/core/-/core-7.16.1.tgz#be9cb3f3288246664804c625f2340b6dbeed2548"
+  integrity sha512-HYdjCeMU3dUJbc1CrAAedeAASTG5kVyL/qsiuYh5b7BoG0qsRtK8WJxBpUjW6VqtJpUaE94c5tlBJ8MgAmPHTQ==
+  dependencies:
+    "@floating-ui/react" "^0.26.28"
+    clsx "^2.1.1"
+    react-number-format "^5.4.3"
+    react-remove-scroll "^2.6.2"
+    react-textarea-autosize "8.5.6"
+    type-fest "^4.27.0"
+
+"@mantine/hooks@^7.16.1":
+  version "7.16.1"
+  resolved "https://registry.yarnpkg.com/@mantine/hooks/-/hooks-7.16.1.tgz#3956b277ac19e456a42f8dceea4933ac4a8d7cb9"
+  integrity sha512-+hER8E4d2ByfQ/DKIXGM3Euxb7IH5ArSjzzzoF21sG095iXIryOCob22ZanrmiXCoAzKKdxqgVj4Di67ikLYSQ==
 
 "@material/animation@^4.0.0":
   version "4.0.0"
@@ -6794,7 +6820,7 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
-clsx@^2, clsx@^2.0.0:
+clsx@^2, clsx@^2.0.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -7838,6 +7864,11 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
 detect-node@^2.0.4:
   version "2.1.0"
@@ -9200,6 +9231,11 @@ get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
     hasown "^2.0.0"
+
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -13983,6 +14019,11 @@ react-markdown@^9:
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
 
+react-number-format@^5.4.3:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-5.4.3.tgz#e634df907da7742faf597afab3f25f9a59689d60"
+  integrity sha512-VCY5hFg/soBighAoGcdE+GagkJq0230qN6jcS5sp8wQX1qy1fYN/RX7/BXkrs0oyzzwqR8/+eSUrqXbGeywdUQ==
+
 react-popper@^2:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
@@ -13995,6 +14036,42 @@ react-refresh@^0:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
+
+react-remove-scroll-bar@^2.3.7:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
+  integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
+  dependencies:
+    react-style-singleton "^2.2.2"
+    tslib "^2.0.0"
+
+react-remove-scroll@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.6.2.tgz#2518d2c5112e71ea8928f1082a58459b5c7a2a97"
+  integrity sha512-KmONPx5fnlXYJQqC62Q+lwIeAk64ws/cUw6omIumRzMRPqgnYqhSSti99nbj0Ry13bv7dF+BKn7NB+OqkdZGTw==
+  dependencies:
+    react-remove-scroll-bar "^2.3.7"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.3"
+    use-sidecar "^1.1.2"
+
+react-style-singleton@^2.2.1, react-style-singleton@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
+  integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
+  dependencies:
+    get-nonce "^1.0.0"
+    tslib "^2.0.0"
+
+react-textarea-autosize@8.5.6:
+  version "8.5.6"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.5.6.tgz#e9205fb215eea7cbb6cba8f57dd874ab5d44a241"
+  integrity sha512-aT3ioKXMa8f6zHYGebhbdMD2L00tKeRX1zuVuDx9YQK/JLLRSaSxq3ugECEmUB9z2kvk6bFSIoRHLkkUv0RJiw==
+  dependencies:
+    "@babel/runtime" "^7.20.13"
+    use-composed-ref "^1.3.0"
+    use-latest "^1.2.1"
 
 react@^18:
   version "18.3.1"
@@ -15793,6 +15870,11 @@ type-fest@^4.26.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.30.0.tgz#cf411e7630578ad9e9884951dfaeef6588f970fe"
   integrity sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==
 
+type-fest@^4.27.0:
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.33.0.tgz#2da0c135b9afa76cf8b18ecfd4f260ecd414a432"
+  integrity sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -16125,6 +16207,38 @@ urlpattern-polyfill@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz#f0a03a97bfb03cdf33553e5e79a2aadd22cac8ec"
   integrity sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==
+
+use-callback-ref@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
+  dependencies:
+    tslib "^2.0.0"
+
+use-composed-ref@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.4.0.tgz#09e023bf798d005286ad85cd20674bdf5770653b"
+  integrity sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==
+
+use-isomorphic-layout-effect@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz#afb292eb284c39219e8cb8d3d62d71999361a21d"
+  integrity sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==
+
+use-latest@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.3.0.tgz#549b9b0d4c1761862072f0899c6f096eb379137a"
+  integrity sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==
+  dependencies:
+    use-isomorphic-layout-effect "^1.1.1"
+
+use-sidecar@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.3.tgz#10e7fd897d130b896e2c546c63a5e8233d00efdb"
+  integrity sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 use-sync-external-store@^1.2.0:
   version "1.2.2"

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -59,6 +59,27 @@
   dependencies:
     node-fetch "^2.6.1"
 
+"@ariakit/core@0.4.14":
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/@ariakit/core/-/core-0.4.14.tgz#a8bbefbc80a1781ae739bdf25a4fd9130fbd5089"
+  integrity sha512-hpzZvyYzGhP09S9jW1XGsU/FD5K3BKsH1eG/QJ8rfgEeUdPS7BvHPt5lHbOeJ2cMrRzBEvsEzLi1ivfDifHsVA==
+
+"@ariakit/react-core@0.4.15":
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/@ariakit/react-core/-/react-core-0.4.15.tgz#333b9ee0f4c12d3b76db06e2d787987c1e3fae27"
+  integrity sha512-Up8+U97nAPJdyUh9E8BCEhJYTA+eVztWpHoo1R9zZfHd4cnBWAg5RHxEmMH+MamlvuRxBQA71hFKY/735fDg+A==
+  dependencies:
+    "@ariakit/core" "0.4.14"
+    "@floating-ui/dom" "^1.0.0"
+    use-sync-external-store "^1.2.0"
+
+"@ariakit/react@^0.4.15":
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/@ariakit/react/-/react-0.4.15.tgz#d088faf0e98e59542f3c23c348b6e923a6054208"
+  integrity sha512-0V2LkNPFrGRT+SEIiObx/LQjR6v3rR+mKEDUu/3tq7jfCZ+7+6Q6EMR1rFaK+XMkaRY1RWUcj/rRDWAUWnsDww==
+  dependencies:
+    "@ariakit/react-core" "0.4.15"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"


### PR DESCRIPTION
**Mantine** — needs a provider, not made for customization, it is impossible to override the internal structure of the component, tooltips are not shown (they appear in the house, but in the wrong place),

Tooltips do not work for custom components without a forward ref (there are many of them in the cloud beaver)

Errors that break hot reload
[0] ../../node_modules/@mantine/core/lib/components/Modal/use-modals-stack.d.ts(13,40): error TS1139: Type parameter declaration expected.
[0] ../../node_modules/@mantine/core/lib/components/Modal/use-modals-stack.d.ts(13,48): error TS1005: ',' expected.
[0] ../../node_modules/@mantine/core/lib/components/Modal/use-modals-stack.d.ts(13,62): error TS1005: ',' expected.
[0] ../../node_modules/@mantine/core/lib/components/Modal/use-modals-stack.d.ts(13,70): error TS1005: ')' expected.
[0] ../../node_modules/@mantine/core/lib/components/Modal/use-modals-stack.d.ts(13,74): error TS1011: An element access expression should take an argument.
[0] ../../node_modules/@mantine/core/lib/components/Modal/use-modals-stack.d.ts(13,75): error TS1005: ';' expected.
[0] ../../node_modules/@mantine/core/lib/components/Modal/use-modals-stack.d.ts(13,76): error TS1128: Declaration or statement expected.

In mode with styles, cloudbeaver webpack could not build the project. Decided to not spend too much time, installed as described here: https://mantine.dev/styles/postcss-preset/

**Base UI** - component creation and usage is straightforward. some of our styles breaks components styles (like Container > *),
Z-index of backdrop hides popups

**AriaKit** - works well from the box, trap autofocus on interactive element inside popover automatically,
Doesn’t have Switch component, tried to implement using Checkbox component