### PR TITLE
fix: rename default localization property from core.localization.loca…

### DIFF
--- a/config/core/cloudbeaver.conf
+++ b/config/core/cloudbeaver.conf
@@ -13,7 +13,7 @@
         productSettings: {
             # Global properties
             core.theming.theme: "${CLOUDBEAVER_CORE_THEMING_THEME:light}",
-            core.localization.localization: "${CLOUDBEAVER_CORE_LOCALIZATION:en}",
+            core.localization.language: "${CLOUDBEAVER_CORE_LOCALIZATION:en}",
             plugin.sql-editor.autoSave: "${CLOUDBEAVER_SQL_EDITOR_AUTOSAVE:true}",
             plugin.sql-editor.disabled: "${CLOUDBEAVER_SQL_EDITOR_DISABLED:false}",
             # max size of the file that can be uploaded to the editor (in kilobytes)


### PR DESCRIPTION
…lization to core.localization.language

It seems like it was a misspelling initially, because we have never read such key in source code.