### PR TITLE
#5265 fix: no icons for users and connections on permission tables (

### DIFF
--- a/webapp/packages/plugin-authentication-administration/src/Administration/Users/Teams/TeamsForm/GrantedConnections/GrantedConnectionsTableItem.module.css
+++ b/webapp/packages/plugin-authentication-administration/src/Administration/Users/Teams/TeamsForm/GrantedConnections/GrantedConnectionsTableItem.module.css
@@ -8,4 +8,5 @@
 .staticImage {
   display: flex;
   width: 24px;
+  min-width: 24px;
 }

--- a/webapp/packages/plugin-authentication-administration/src/Administration/Users/Teams/TeamsForm/GrantedUsers/GrantedUsersTableItem.module.css
+++ b/webapp/packages/plugin-authentication-administration/src/Administration/Users/Teams/TeamsForm/GrantedUsers/GrantedUsersTableItem.module.css
@@ -8,4 +8,5 @@
 .staticImage {
   display: flex;
   width: 24px;
+  min-width: 24px;
 }

--- a/webapp/packages/plugin-authentication-administration/src/Administration/Users/UserForm/ConnectionAccess/UserFormConnectionTableItem.module.css
+++ b/webapp/packages/plugin-authentication-administration/src/Administration/Users/UserForm/ConnectionAccess/UserFormConnectionTableItem.module.css
@@ -1,0 +1,4 @@
+.staticImage {
+    width: 24px;
+    min-width: 24px;
+  }

--- a/webapp/packages/plugin-authentication-administration/src/Administration/Users/UserForm/ConnectionAccess/UserFormConnectionTableItem.tsx
+++ b/webapp/packages/plugin-authentication-administration/src/Administration/Users/UserForm/ConnectionAccess/UserFormConnectionTableItem.tsx
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2024 DBeaver Corp and others
+ * Copyright (C) 2020-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@ import { AdminSubjectType } from '@cloudbeaver/core-sdk';
 import { useTabState } from '@cloudbeaver/core-ui';
 
 import type { UserFormConnectionAccessPart } from './UserFormConnectionAccessPart.js';
+
+import style from './UserFormConnectionTableItem.module.css';
 
 interface Props {
   connection: Connection;
@@ -45,7 +47,7 @@ export const UserFormConnectionTableItem = observer<Props>(function UserFormConn
         <TableItemSelect disabled={disabled} checked={selected} />
       </TableColumnValue>
       <TableColumnValue centerContent>
-        <StaticImage icon={driver?.icon} width={24} block />
+        <StaticImage className={style['staticImage']} icon={driver?.icon} width={24} block />
       </TableColumnValue>
       <TableColumnValue title={connection.name} ellipsis>
         {connection.name}

--- a/webapp/packages/plugin-authentication-administration/src/Administration/Users/UserForm/ConnectionAccess/UserFormConnectionTableItem.tsx
+++ b/webapp/packages/plugin-authentication-administration/src/Administration/Users/UserForm/ConnectionAccess/UserFormConnectionTableItem.tsx
@@ -47,7 +47,7 @@ export const UserFormConnectionTableItem = observer<Props>(function UserFormConn
         <TableItemSelect disabled={disabled} checked={selected} />
       </TableColumnValue>
       <TableColumnValue centerContent>
-        <StaticImage className={style['staticImage']} icon={driver?.icon} width={24} block />
+        <StaticImage className={style['staticImage']} icon={driver?.icon} block />
       </TableColumnValue>
       <TableColumnValue title={connection.name} ellipsis>
         {connection.name}


### PR DESCRIPTION
closes [#5265](https://github.com/dbeaver/pro/issues/5265)

CB-6373
<img width="724" alt="Screenshot 2025-03-31 at 11 33 19" src="https://github.com/user-attachments/assets/7f1050d3-66db-45c8-ac4a-80c93f0ca2d6" />
<img width="823" alt="Screenshot 2025-03-31 at 11 33 23" src="https://github.com/user-attachments/assets/1279c311-4cc2-411d-8381-b248994f4afe" />
