### PR TITLE
#5258 fix: See permission error after finish easy config

### DIFF
--- a/webapp/packages/plugin-authentication/src/AuthenticationService.ts
+++ b/webapp/packages/plugin-authentication/src/AuthenticationService.ts
@@ -205,8 +205,8 @@ export class AuthenticationService extends Bootstrap {
     this.administrationScreenService.ensurePermissions.addHandler(async () => {
       await this.waitAuth();
 
-      const userInfo = await this.userInfoResource.load();
-      if (userInfo && !userInfo.isAnonymous) {
+      await this.userInfoResource.load();
+      if (this.userInfoResource.isAuthenticated()) {
         return;
       }
 

--- a/webapp/packages/plugin-authentication/src/AuthenticationService.ts
+++ b/webapp/packages/plugin-authentication/src/AuthenticationService.ts
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2024 DBeaver Corp and others
+ * Copyright (C) 2020-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -206,7 +206,7 @@ export class AuthenticationService extends Bootstrap {
       await this.waitAuth();
 
       const userInfo = await this.userInfoResource.load();
-      if (userInfo) {
+      if (userInfo && !userInfo.isAnonymous) {
         return;
       }
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/d82c05e4-f96f-4d45-9724-0e306ce9d46b

We try to open /admin route as described in configuration wizard and show auth dialog. If user cancels, we show notification and redirect to app.