### PR TITLE
dbeaver/pro#5192 adjust loading state process

### DIFF
--- a/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/ElementsTreeContentLoader.tsx
+++ b/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/ElementsTreeContentLoader.tsx
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2024 DBeaver Corp and others
+ * Copyright (C) 2020-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,7 @@ export const ElementsTreeContentLoader = observer<React.PropsWithChildren<Props>
   children,
 }) {
   const hasChildren = getComputed(() => context.tree.getNodeChildren(context.tree.root).length > 0);
-
-  const loading = getComputed(() => (childrenState.isLoading() || context.tree.isLoading()) && !context.tree.isLoaded());
+  const loading = getComputed(() => childrenState.isLoading() || context.tree.isLoading() || context.tree.isOutdated?.());
 
   if (!hasChildren) {
     if (loading) {

--- a/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/useElementsTree.ts
+++ b/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/useElementsTree.ts
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2024 DBeaver Corp and others
+ * Copyright (C) 2020-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -420,6 +420,9 @@ export function useElementsTree(options: IOptions): IElementsTree {
       },
       isLoaded(): boolean {
         return navNodeInfoResource.isLoaded(this.root);
+      },
+      isOutdated(): boolean {
+        return navNodeInfoResource.isOutdated(this.root);
       },
       getNodeState(nodeId: string) {
         return this.state.get(nodeId);


### PR DESCRIPTION
closes [5192](https://github.com/dbeaver/pro/issues/5192)

We dont need to check if root was loaded in loading variable because if we have children, we dont show a spinner anyway, instead we show navigation tree and update it in the background. If root is outdated and we dont have children, we want to show the spinner