### PR TITLE
dbeaver/pro#5406 use more specific resource

### DIFF
--- a/webapp/packages/plugin-connections/src/ContextMenu/ConnectionMenuBootstrap.ts
+++ b/webapp/packages/plugin-connections/src/ContextMenu/ConnectionMenuBootstrap.ts
@@ -7,6 +7,7 @@
  */
 import {
   type Connection,
+  ConnectionInfoAuthPropertiesResource,
   ConnectionInfoResource,
   ConnectionsManagerService,
   ConnectionsSettingsService,
@@ -45,6 +46,7 @@ export class ConnectionMenuBootstrap extends Bootstrap {
   constructor(
     private readonly notificationService: NotificationService,
     private readonly connectionInfoResource: ConnectionInfoResource,
+    private readonly connectionInfoAuthPropertiesResource: ConnectionInfoAuthPropertiesResource,
     private readonly navNodeManagerService: NavNodeManagerService,
     private readonly connectionsManagerService: ConnectionsManagerService,
     private readonly actionService: ActionService,
@@ -203,12 +205,7 @@ export class ConnectionMenuBootstrap extends Bootstrap {
       getLoader: (context, action) => {
         const connectionKey = context.get(DATA_CONTEXT_CONNECTION)!;
         if (action === ACTION_CONNECTION_CHANGE_CREDENTIALS) {
-          return getCachedMapResourceLoaderState(
-            this.connectionInfoResource,
-            () => connectionKey,
-            () => ['includeCredentialsSaved' as const],
-            true,
-          );
+          return getCachedMapResourceLoaderState(this.connectionInfoAuthPropertiesResource, () => connectionKey, undefined, true);
         }
 
         return getCachedMapResourceLoaderState(this.connectionInfoResource, () => connectionKey, undefined, true);

--- a/webapp/packages/plugin-connections/src/ContextMenu/ConnectionMenuBootstrap.ts
+++ b/webapp/packages/plugin-connections/src/ContextMenu/ConnectionMenuBootstrap.ts
@@ -197,7 +197,8 @@ export class ConnectionMenuBootstrap extends Bootstrap {
         }
 
         if (action === ACTION_CONNECTION_CHANGE_CREDENTIALS) {
-          return !this.serverConfigResource.distributed || connection.sharedCredentials;
+          const auth = this.connectionInfoAuthPropertiesResource.get(connectionKey);
+          return !this.serverConfigResource.distributed || !!auth?.sharedCredentials;
         }
 
         return true;


### PR DESCRIPTION
closes [5406](https://github.com/dbeaver/pro/issues/5406)

We should use a more specific resource instead of `connectionInfoResource` There are many components that rely on the main resource, and it should only be used when all connection data is required. That’s not the case here.

Also we dont use includes anymore