### PR TITLE
dbeaver/pro#5779 fix: external app plugin naming

### DIFF
--- a/webapp/packages/product-base/src/baseConfigurationPlugin.ts
+++ b/webapp/packages/product-base/src/baseConfigurationPlugin.ts
@@ -63,7 +63,7 @@ export function baseConfigurationPlugin(mode: string, packageJson: any): PluginO
                 changeOrigin: true,
                 secure: false,
               },
-              '/auth-complex': {
+              '/auth-external': {
                 target: envServer,
                 changeOrigin: true,
                 secure: false,


### PR DESCRIPTION
closes dbeaver/pro#5779