### PR TITLE
Correct broken P2 repository URL for local development setup

### DIFF
--- a/osgi-app.properties
+++ b/osgi-app.properties
@@ -16,7 +16,7 @@ testLibraries=\
   org.hamcrest.core;\
   org.hamcrest
 repositories=\
-  https://repo.dbeaver.net/p2/ce/;\
+  https://repo.dbeaver.net/p2/ce/latest/;\
   https://download.eclipse.org/releases/${eclipse-version}/;
 testBundles=\
   org.junit;\


### PR DESCRIPTION
Context & Verification
This issue is identical to one recently resolved in the main DBeaver repository. The fix applied here mirrors the official fix from the DBeaver team.

The original discussion can be found here:
https://github.com/orgs/dbeaver/discussions/38420

The official fix in the DBeaver repository is this commit:
https://github.com/dbeaver/dbeaver/commit/00824540240c5104709e60948af92a89b6921ce1