### PR TITLE
dbeaver/pro#4025 Downgrade db2 default driver version to 11.5.9

### DIFF
--- a/server/drivers/db2/pom.xml
+++ b/server/drivers/db2/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.ibm.db2</groupId>
             <artifactId>jcc</artifactId>
-            <version>12.1.0.0</version>
+            <version>11.5.9.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Downgraded db2 default driver version to 11.5.9 due to lack of DB2 Kerberos support in 12.1

[jcc][t4][2035][11153][4.34.30] DSS chained with same id at end of same id chain parse. ERRORCODE=-4499, SQLSTATE=null

Upgrade was done in #3460 as a potential fix to allow changing password but didn't help.