### PR TITLE
dbeaver/pro#6150 sync options part

### DIFF
--- a/webapp/packages/plugin-connections/src/ConnectionForm/DriverProperties/ConnectionFormDriverPropertiesPart.ts
+++ b/webapp/packages/plugin-connections/src/ConnectionForm/DriverProperties/ConnectionFormDriverPropertiesPart.ts
@@ -10,7 +10,7 @@ import type { IExecutionContextProvider } from '@cloudbeaver/core-executor';
 import { ConnectionInfoPropertiesResource } from '@cloudbeaver/core-connections';
 import type { IConnectionFormState } from '../IConnectionFormState.js';
 import type { IConnectionProperties } from '../Options/IConnectionConfig.js';
-import { observable, runInAction } from 'mobx';
+import { observable, runInAction, toJS } from 'mobx';
 import type { ConnectionFormOptionsPart } from '../Options/ConnectionFormOptionsPart.js';
 
 function getDefaultState(): IConnectionProperties {
@@ -40,6 +40,11 @@ export class ConnectionFormDriverPropertiesPart extends FormPart<IConnectionProp
     return this.connectionInfoPropertiesResource.isOutdated(this.optionsPart.connectionKey);
   }
 
+  protected override setState(state: Record<string, any>): void {
+    super.setState(state);
+    this.optionsPart.state.properties = this.state;
+  }
+
   protected override async loader(): Promise<void> {
     if (!this.optionsPart.connectionKey) {
       this.setInitialState(getDefaultState());
@@ -47,8 +52,10 @@ export class ConnectionFormDriverPropertiesPart extends FormPart<IConnectionProp
     }
 
     const connection = await this.connectionInfoPropertiesResource.load(this.optionsPart.connectionKey);
+    const properties = toJS(connection.properties);
 
-    this.setInitialState({ ...connection.properties });
+    this.setInitialState(properties);
+    this.optionsPart.initialState.properties = properties;
   }
 
   protected override async saveChanges(

--- a/webapp/packages/plugin-connections/src/ConnectionForm/DriverProperties/ConnectionFormDriverPropertiesPart.ts
+++ b/webapp/packages/plugin-connections/src/ConnectionForm/DriverProperties/ConnectionFormDriverPropertiesPart.ts
@@ -10,7 +10,7 @@ import type { IExecutionContextProvider } from '@cloudbeaver/core-executor';
 import { ConnectionInfoPropertiesResource } from '@cloudbeaver/core-connections';
 import type { IConnectionFormState } from '../IConnectionFormState.js';
 import type { IConnectionProperties } from '../Options/IConnectionConfig.js';
-import { observable, runInAction, toJS } from 'mobx';
+import { runInAction, toJS } from 'mobx';
 import type { ConnectionFormOptionsPart } from '../Options/ConnectionFormOptionsPart.js';
 
 function getDefaultState(): IConnectionProperties {
@@ -45,6 +45,11 @@ export class ConnectionFormDriverPropertiesPart extends FormPart<IConnectionProp
     this.optionsPart.state.properties = this.state;
   }
 
+  protected override setInitialState(initialState: Record<string, any>): void {
+    super.setInitialState(initialState);
+    this.optionsPart.initialState.properties = initialState;
+  }
+
   protected override async loader(): Promise<void> {
     if (!this.optionsPart.connectionKey) {
       this.setInitialState(getDefaultState());
@@ -55,7 +60,6 @@ export class ConnectionFormDriverPropertiesPart extends FormPart<IConnectionProp
     const properties = toJS(connection.properties);
 
     this.setInitialState(properties);
-    this.optionsPart.initialState.properties = properties;
   }
 
   protected override async saveChanges(
@@ -73,12 +77,6 @@ export class ConnectionFormDriverPropertiesPart extends FormPart<IConnectionProp
           this.state[key] = this.state[key].trim();
         }
       }
-
-      if (!this.optionsPart.state.properties) {
-        this.optionsPart.state.properties = observable({});
-      }
-
-      Object.assign(this.optionsPart.state.properties, this.state);
     });
   }
 }

--- a/webapp/packages/plugin-connections/src/ConnectionForm/DriverProperties/DriverProperties.tsx
+++ b/webapp/packages/plugin-connections/src/ConnectionForm/DriverProperties/DriverProperties.tsx
@@ -9,7 +9,7 @@ import { computed, observable, runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import { useMemo, useState } from 'react';
 
-import { ColoredContainer, Group, type IProperty, PropertiesTable, s, useAutoLoad, useResource, useS } from '@cloudbeaver/core-blocks';
+import { ColoredContainer, Group, type IProperty, PropertiesTable, s, useAutoLoad, useExecutor, useResource, useS } from '@cloudbeaver/core-blocks';
 import { DBDriverResource } from '@cloudbeaver/core-connections';
 import { type TabContainerPanelComponent, useTab } from '@cloudbeaver/core-ui';
 import { uuid } from '@cloudbeaver/core-utils';
@@ -24,6 +24,7 @@ export const DriverProperties: TabContainerPanelComponent<IConnectionFormProps> 
   const style = useS(styles);
   const driverPropertiesPart = getConnectionFormDriverPropertiesPart(formState);
   const optionsPart = getConnectionFormOptionsPart(formState);
+
   const [state] = useState(() => {
     const propertiesList: IProperty[] = observable([]);
 
@@ -41,7 +42,20 @@ export const DriverProperties: TabContainerPanelComponent<IConnectionFormProps> 
       propertiesList.splice(propertiesList.indexOf(property), 1);
     }
 
-    return { propertiesList, add, remove };
+    function reset() {
+      propertiesList.splice(0, propertiesList.length);
+    }
+
+    return { propertiesList, add, remove, reset };
+  });
+
+  useExecutor({
+    executor: optionsPart.onDriverIdChange,
+    handlers: [
+      function handleDriverChange() {
+        state.reset();
+      },
+    ],
   });
 
   const driver = useResource(DriverProperties, DBDriverResource, {

--- a/webapp/packages/plugin-connections/src/ConnectionForm/Options/ConnectionFormOptionsPart.ts
+++ b/webapp/packages/plugin-connections/src/ConnectionForm/Options/ConnectionFormOptionsPart.ts
@@ -312,9 +312,8 @@ export class ConnectionFormOptionsPart extends FormPart<IConnectionFormOptionsSt
       this.state.credentials = {};
       this.state.providerProperties = {};
       await this.setAuthModelId(driver?.defaultAuthModel);
+      await this.onDriverIdChange.execute(this.state.driverId);
     }
-
-    await this.onDriverIdChange.execute(this.state.driverId);
   }
 
   async setAuthModelId(modelId: string | undefined): Promise<void> {

--- a/webapp/packages/plugin-connections/src/ConnectionForm/Options/ConnectionFormOptionsPart.ts
+++ b/webapp/packages/plugin-connections/src/ConnectionForm/Options/ConnectionFormOptionsPart.ts
@@ -49,7 +49,6 @@ const defaultStateGetter = (connectionId?: string, credentials?: Record<string, 
     credentials: credentials ?? {},
     mainPropertyValues: {},
     networkHandlersConfig: [],
-    properties: {},
     providerProperties: {},
   }) as IConnectionFormOptionsState;
 


### PR DESCRIPTION
closes [6150](https://github.com/dbeaver/pro/issues/6150)

Two additional bugs were fixed as part of this ticket:

If custom properties were defined and any changes were made to the connection options without visiting the Properties tab, all custom properties were deleted.

If custom properties were created and the driver was changed, the properties remained persistent across drivers.