### PR TITLE
dbeaver/pro#6105 fix: form validation fails on test in GCP

### DIFF
--- a/webapp/packages/plugin-connections/src/ConnectionForm/Options/Options.tsx
+++ b/webapp/packages/plugin-connections/src/ConnectionForm/Options/Options.tsx
@@ -48,7 +48,7 @@ import { useService } from '@cloudbeaver/core-di';
 import { ProjectInfoResource } from '@cloudbeaver/core-projects';
 import { EAdminPermission, ServerConfigResource } from '@cloudbeaver/core-root';
 import { DriverConfigurationType } from '@cloudbeaver/core-sdk';
-import { type TabContainerPanelComponent, TabsContext, useTab } from '@cloudbeaver/core-ui';
+import { type TabContainerPanelComponent, TabsContext } from '@cloudbeaver/core-ui';
 import { EMPTY_ARRAY } from '@cloudbeaver/core-utils';
 import { ProjectSelect } from '@cloudbeaver/plugin-projects';
 
@@ -86,11 +86,8 @@ const driverConfiguration: IDriverConfiguration[] = [
 ];
 
 export const Options: TabContainerPanelComponent<IConnectionFormProps> = observer(function Options({ formState, tabId }) {
-  const { selected } = useTab(tabId);
   const isAdmin = usePermission(EAdminPermission.admin);
-  const serverConfigResource = useResource(Options, ServerConfigResource, undefined, {
-    active: selected,
-  });
+  const serverConfigResource = useResource(Options, ServerConfigResource, undefined);
   const projectInfoResource = useService(ProjectInfoResource);
   const formRef = useRef<HTMLFormElement>(null);
   const translate = useTranslate();
@@ -98,15 +95,9 @@ export const Options: TabContainerPanelComponent<IConnectionFormProps> = observe
   const tabsState = useContext(TabsContext);
   const isSharedProject = projectInfoResource.isProjectShared(formState.state.projectId);
   const optionsPart = getConnectionFormOptionsPart(formState);
-  const connectionInfoAuthResource = useResource(Options, ConnectionInfoAuthPropertiesResource, optionsPart.connectionKey, {
-    active: selected && !!optionsPart.connectionKey,
-  });
-  const connectionInfoOriginResource = useResource(Options, ConnectionInfoOriginResource, optionsPart.connectionKey, {
-    active: selected && !!optionsPart.connectionKey,
-  });
-  const connectionInfoAuthPropertiesResource = useResource(Options, ConnectionInfoAuthPropertiesResource, optionsPart.connectionKey, {
-    active: selected && !!optionsPart.connectionKey,
-  });
+  const connectionInfoAuthResource = useResource(Options, ConnectionInfoAuthPropertiesResource, optionsPart.connectionKey);
+  const connectionInfoOriginResource = useResource(Options, ConnectionInfoOriginResource, optionsPart.connectionKey);
+  const connectionInfoAuthPropertiesResource = useResource(Options, ConnectionInfoAuthPropertiesResource, optionsPart.connectionKey);
   const configurationTypeLabel = translate('connections_connection_configuration');
 
   //@TODO it's here until the profile implementation in the CloudBeaver
@@ -115,17 +106,10 @@ export const Options: TabContainerPanelComponent<IConnectionFormProps> = observe
   useFormValidator(formState.validationTask, formRef.current);
   const { credentialsSavingEnabled } = useAdministrationSettings();
 
-  const driverMap = useResource(
-    Options,
-    DBDriverResource,
-    {
-      key: optionsPart.state.driverId || null,
-      includes: ['includeProviderProperties', 'includeMainProperties', 'includeDriverProperties'] as const,
-    },
-    {
-      active: selected,
-    },
-  );
+  const driverMap = useResource(Options, DBDriverResource, {
+    key: optionsPart.state.driverId || null,
+    includes: ['includeProviderProperties', 'includeMainProperties', 'includeDriverProperties'] as const,
+  });
 
   const driver = driverMap.data;
   const configurationTypes = driverConfiguration.filter(configuration => driver && configuration.isVisible(driver));
@@ -136,9 +120,6 @@ export const Options: TabContainerPanelComponent<IConnectionFormProps> = observe
     Options,
     DatabaseAuthModelsResource,
     getComputed(() => optionsPart.state.authModelId || connectionInfoAuthResource.data?.authModel || driver?.defaultAuthModel || null),
-    {
-      active: selected,
-    },
   );
 
   const authModel = authModelLoader.data;
@@ -188,7 +169,7 @@ export const Options: TabContainerPanelComponent<IConnectionFormProps> = observe
     await optionsPart.setDriverId(driverId);
   }
 
-  useAutoLoad(Options, optionsPart, selected);
+  useAutoLoad(Options, optionsPart);
 
   return (
     <Form ref={formRef} className={s(style, { form: true })} disabled={driverMap.isLoading()}>


### PR DESCRIPTION
Removed active state from Options component resources because it unload resources when we switch to other tabs which leads to broken connection form state and entails data inconsistency.

For example, the check driver?.useCustomPage fails because driver resource has been unloaded and the component renders standard Parameters form instead of custom taking state from the wrong destination.