### PR TITLE
dbeaver/pro#5968 refactor: update dark theme styles

### DIFF
--- a/webapp/packages/core-blocks/src/Button.css
+++ b/webapp/packages/core-blocks/src/Button.css
@@ -24,10 +24,10 @@
     --dbv-kit-btn-secondary-background: transparent;
     --dbv-kit-btn-secondary-background-hover: color-mix(in srgb, transparent, var(--theme-primary) 5%);
     --dbv-kit-btn-secondary-background-active: color-mix(in srgb, transparent, var(--theme-primary) 20%);
-    --dbv-kit-btn-secondary-foreground: var(--theme-primary);
-    --dbv-kit-btn-secondary-foreground-hover: var(--theme-primary);
-    --dbv-kit-btn-secondary-foreground-active: var(--theme-primary);
-    --dbv-kit-btn-secondary-border-color: var(--theme-primary);
+    --dbv-kit-btn-secondary-foreground: var(--theme-link-color);
+    --dbv-kit-btn-secondary-foreground-hover: var(--theme-link-color);
+    --dbv-kit-btn-secondary-foreground-active: var(--theme-link-color);
+    --dbv-kit-btn-secondary-border-color: var(--theme-link-color);
 
     --dbv-kit-btn-danger-background: var(--theme-negative);
     --dbv-kit-btn-danger-background-hover: color-mix(in srgb, var(--theme-negative), white 10%);

--- a/webapp/packages/core-theming/src/styles/_theme-dark.scss
+++ b/webapp/packages/core-theming/src/styles/_theme-dark.scss
@@ -22,7 +22,7 @@ $mdc-theme-error: #e94948;
 $color-scheme: dark;
 $color-positive: #52c41a;
 $color-on-positive: #fff;
-$color-negative: #e73e52;
+$color-negative: hsl(0, 85%, 45%);
 $color-status: #a08600;
 
 $link-color: lighten($mdc-theme-primary, 10%);

--- a/webapp/packages/core-theming/src/styles/_theme-dark.scss
+++ b/webapp/packages/core-theming/src/styles/_theme-dark.scss
@@ -8,15 +8,15 @@
 
 $mdc-theme-primary: #2a7cb4;
 $mdc-theme-on-primary: #ffffff;
-$mdc-theme-secondary: hsl(240deg, 10%, 15%);
+$mdc-theme-secondary: hsl(240deg, 10%, 13%);
 $mdc-theme-on-secondary: #cbcbcb;
 
-$mdc-theme-sub-secondary: hsl(240deg, 10%, 20%);
+$mdc-theme-sub-secondary: hsl(240deg, 10%, 18%);
 $mdc-theme-on-sub-secondary: #cbcbcb;
 
-$mdc-theme-surface: hsl(240deg, 8%, 16%);
+$mdc-theme-surface: hsl(240deg, 10%, 16%);
 $mdc-theme-on-surface: #ffffff;
-$mdc-theme-background: hsl(240deg, 10%, 26%);
+$mdc-theme-background: hsl(240deg, 10%, 25%);
 $mdc-theme-error: #e94948;
 
 $color-scheme: dark;

--- a/webapp/packages/core-theming/src/styles/_theme-dark.scss
+++ b/webapp/packages/core-theming/src/styles/_theme-dark.scss
@@ -22,7 +22,7 @@ $mdc-theme-error: #e94948;
 $color-scheme: dark;
 $color-positive: #52c41a;
 $color-on-positive: #fff;
-$color-negative: hsl(0, 85%, 45%);
+$color-negative: hsl(0, 95%, 65%);
 $color-status: #a08600;
 
 $link-color: lighten($mdc-theme-primary, 10%);

--- a/webapp/packages/core-theming/src/styles/_theme-dark.scss
+++ b/webapp/packages/core-theming/src/styles/_theme-dark.scss
@@ -14,7 +14,7 @@ $mdc-theme-on-secondary: #cbcbcb;
 $mdc-theme-sub-secondary: hsl(240deg, 10%, 20%);
 $mdc-theme-on-sub-secondary: #cbcbcb;
 
-$mdc-theme-surface: hsl(240deg, 10%, 18%);
+$mdc-theme-surface: hsl(240deg, 8%, 16%);
 $mdc-theme-on-surface: #ffffff;
 $mdc-theme-background: hsl(240deg, 10%, 26%);
 $mdc-theme-error: #e94948;
@@ -25,7 +25,7 @@ $color-on-positive: #fff;
 $color-negative: #e73e52;
 $color-status: #a08600;
 
-$link-color: $mdc-theme-primary;
+$link-color: lighten($mdc-theme-primary, 10%);
 $link-color-focus: #3f96d1;
 
 $input-color: $mdc-theme-on-secondary;

--- a/webapp/packages/core-theming/src/styles/_variables.scss
+++ b/webapp/packages/core-theming/src/styles/_variables.scss
@@ -13,6 +13,7 @@ $mdc-theme-extra-property-values: (
   on-positive: $color-on-positive,
   negative: $color-negative,
   status: $color-status,
+  link-color: $link-color,
   input-color: $input-color,
   input-color-disabled: $input-color-disabled,
   input-color-readonly: $input-color-readonly,


### PR DESCRIPTION
introduces new theme variable link-color which with a color which is used for coloring anchor elements in our app adjust this color in dark theme to have better contrast with a background, use this color in secondary button for the same reasons
slightly darken the surface color to have better contrast ratio without making the primary color too bright.
<img width="1501" height="611" alt="Screenshot 2025-08-06 at 15 39 02" src="https://github.com/user-attachments/assets/1f03cb6f-6b3a-43b9-b8fc-768fc3a5e1d2" />
<img width="1510" height="609" alt="Screenshot 2025-08-06 at 15 41 20" src="https://github.com/user-attachments/assets/b1bdf19a-47ef-4cc4-b55d-2c598ad3c2ac" />
