### PR TITLE
[CB] SQL semantic autocompletion doesn't take into account current schema

### DIFF
--- a/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
+++ b/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
@@ -29,16 +29,10 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
   const optionsRef = useObjectRef({ data });
 
   const [config] = useState<CompletionConfig>(() => {
-    function getOptionsFromProposals(explicit: boolean, word: string, proposals: SQLProposal[]): SqlCompletion[] {
-      const wordLowerCase = word.toLocaleLowerCase();
-      const hasSameName = proposals.some(
-        ({ replacementString, displayString }) =>
-          sanitizeProposal(displayString) === wordLowerCase || replacementString.toLocaleLowerCase() === wordLowerCase,
-      );
-
+    function getOptionsFromProposals(explicit: boolean, proposals: SQLProposal[]): SqlCompletion[] {
       const orderedProposals = proposals.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
 
-      if (orderedProposals.length === 0 && !hasSameName && explicit) {
+      if (orderedProposals.length === 0 && explicit) {
         return [
           {
             apply: closeCompletion,
@@ -77,7 +71,7 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
 
         const result: CompletionResult = {
           from: word.from,
-          options: getOptionsFromProposals(context.explicit, word.text, proposals),
+          options: getOptionsFromProposals(context.explicit, proposals),
           update(current, from, to, context) {
             if (startPos > context.pos) {
               return null;
@@ -103,7 +97,7 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
 
             return {
               ...current,
-              options: getOptionsFromProposals(context.explicit, word.text, proposals),
+              options: getOptionsFromProposals(context.explicit, proposals),
             };
           },
           filter: false,
@@ -142,8 +136,4 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
   });
 
   return useEditorAutocompletion(config);
-}
-
-function sanitizeProposal(value: string): string {
-  return value.replace(/^"|"$/g, '').toLocaleLowerCase();
 }

--- a/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
+++ b/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
@@ -35,20 +35,10 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
         ({ replacementString, displayString }) =>
           sanitizeProposal(displayString) === wordLowerCase || replacementString.toLocaleLowerCase() === wordLowerCase,
       );
-      const filteredProposals = proposals
-        .filter(
-          ({ replacementString, displayString }) => {
-            const display = sanitizeProposal(displayString);
-            const replacement = replacementString.toLocaleLowerCase();
 
-            return word === '*' ||
-              (display !== wordLowerCase && display.startsWith(wordLowerCase)) ||
-              (replacement !== wordLowerCase && replacement.startsWith(wordLowerCase));
-          }
-        )
-        .sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+      const orderedProposals = proposals.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
 
-      if (filteredProposals.length === 0 && !hasSameName && explicit) {
+      if (orderedProposals.length === 0 && !hasSameName && explicit) {
         return [
           {
             apply: closeCompletion,
@@ -58,7 +48,7 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
       }
 
       return [
-        ...filteredProposals.map<SqlCompletion>(proposal => ({
+        ...orderedProposals.map<SqlCompletion>(proposal => ({
           label: proposal.displayString,
           apply: (view, completion, from, to) => {
             view.dispatch(insertCompletionText(view.state, proposal.replacementString, proposal.replacementOffset, to));

--- a/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
+++ b/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
@@ -35,10 +35,20 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
         ({ replacementString, displayString }) =>
           sanitizeProposal(displayString) === wordLowerCase || replacementString.toLocaleLowerCase() === wordLowerCase,
       );
+      const filteredProposals = proposals
+        .filter(
+          ({ replacementString, displayString }) => {
+            const display = sanitizeProposal(displayString);
+            const replacement = replacementString.toLocaleLowerCase();
 
-      const orderedProposals = proposals.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+            return word === '*' ||
+              (display !== wordLowerCase && display.startsWith(wordLowerCase)) ||
+              (replacement !== wordLowerCase && replacement.startsWith(wordLowerCase));
+          }
+        )
+        .sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
 
-      if (orderedProposals.length === 0 && !hasSameName && explicit) {
+      if (filteredProposals.length === 0 && !hasSameName && explicit) {
         return [
           {
             apply: closeCompletion,
@@ -48,7 +58,7 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
       }
 
       return [
-        ...orderedProposals.map<SqlCompletion>(proposal => ({
+        ...filteredProposals.map<SqlCompletion>(proposal => ({
           label: proposal.displayString,
           apply: (view, completion, from, to) => {
             view.dispatch(insertCompletionText(view.state, proposal.replacementString, proposal.replacementOffset, to));

--- a/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
+++ b/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
@@ -13,6 +13,7 @@ import { LocalizationService } from '@cloudbeaver/core-localization';
 import { GlobalConstants } from '@cloudbeaver/core-utils';
 import type { Compartment, Completion, CompletionConfig, CompletionContext, CompletionResult, Extension } from '@cloudbeaver/plugin-codemirror6';
 import { type ISQLEditorData, type SQLProposal } from '@cloudbeaver/plugin-sql-editor';
+import type { SqlCompletionProposal } from '@cloudbeaver/core-sdk';
 
 const codemirrorComplexLoader = createComplexLoader(() => import('@cloudbeaver/plugin-codemirror6'));
 
@@ -31,18 +32,11 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
   const [config] = useState<CompletionConfig>(() => {
     function getOptionsFromProposals(explicit: boolean, word: string, proposals: SQLProposal[]): SqlCompletion[] {
       const wordLowerCase = word.toLocaleLowerCase();
-      const hasSameName = proposals.some(
-        ({ replacementString, displayString }) =>
-          sanitizeProposal(displayString) === wordLowerCase || replacementString.toLocaleLowerCase() === wordLowerCase,
-      );
-      const filteredProposals = proposals
-        .filter(({ replacementString, displayString }) => {
-          const display = sanitizeProposal(displayString);
-          const replacement = replacementString.toLocaleLowerCase();
-
-          return word === '*' || display !== wordLowerCase || replacement !== wordLowerCase;
-        })
-        .sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+      function isSameName(proposal: SqlCompletionProposal) {
+        return sanitizeProposal(proposal.displayString) === wordLowerCase || proposal.replacementString.toLocaleLowerCase() === wordLowerCase;
+      }
+      const hasSameName = proposals.some(isSameName);
+      const filteredProposals = proposals.filter(proposal => !isSameName(proposal)).sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
 
       if (filteredProposals.length === 0 && !hasSameName && explicit) {
         return [

--- a/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
+++ b/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
@@ -36,16 +36,12 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
           sanitizeProposal(displayString) === wordLowerCase || replacementString.toLocaleLowerCase() === wordLowerCase,
       );
       const filteredProposals = proposals
-        .filter(
-          ({ replacementString, displayString }) => {
-            const display = sanitizeProposal(displayString);
-            const replacement = replacementString.toLocaleLowerCase();
+        .filter(({ replacementString, displayString }) => {
+          const display = sanitizeProposal(displayString);
+          const replacement = replacementString.toLocaleLowerCase();
 
-            return word === '*' ||
-              (display !== wordLowerCase && display.startsWith(wordLowerCase)) ||
-              (replacement !== wordLowerCase && replacement.startsWith(wordLowerCase));
-          }
-        )
+          return word === '*' || display !== wordLowerCase || replacement !== wordLowerCase;
+        })
         .sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
 
       if (filteredProposals.length === 0 && !hasSameName && explicit) {

--- a/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
+++ b/webapp/packages/plugin-sql-editor-new/src/SQLEditor/useSqlDialectAutocompletion.ts
@@ -29,10 +29,16 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
   const optionsRef = useObjectRef({ data });
 
   const [config] = useState<CompletionConfig>(() => {
-    function getOptionsFromProposals(explicit: boolean, proposals: SQLProposal[]): SqlCompletion[] {
+    function getOptionsFromProposals(explicit: boolean, word: string, proposals: SQLProposal[]): SqlCompletion[] {
+      const wordLowerCase = word.toLocaleLowerCase();
+      const hasSameName = proposals.some(
+        ({ replacementString, displayString }) =>
+          sanitizeProposal(displayString) === wordLowerCase || replacementString.toLocaleLowerCase() === wordLowerCase,
+      );
+
       const orderedProposals = proposals.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
 
-      if (orderedProposals.length === 0 && explicit) {
+      if (orderedProposals.length === 0 && !hasSameName && explicit) {
         return [
           {
             apply: closeCompletion,
@@ -71,7 +77,7 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
 
         const result: CompletionResult = {
           from: word.from,
-          options: getOptionsFromProposals(context.explicit, proposals),
+          options: getOptionsFromProposals(context.explicit, word.text, proposals),
           update(current, from, to, context) {
             if (startPos > context.pos) {
               return null;
@@ -97,7 +103,7 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
 
             return {
               ...current,
-              options: getOptionsFromProposals(context.explicit, proposals),
+              options: getOptionsFromProposals(context.explicit, word.text, proposals),
             };
           },
           filter: false,
@@ -136,4 +142,8 @@ export function useSqlDialectAutocompletion(data: ISQLEditorData): [Compartment,
   });
 
   return useEditorAutocompletion(config);
+}
+
+function sanitizeProposal(value: string): string {
+  return value.replace(/^"|"$/g, '').toLocaleLowerCase();
 }


### PR DESCRIPTION
seems like we had filtering logic cause backend had sent not all valid options

since then now it seems to be sending relevant proposals so I decided to remove this logic at all keeping only sorting by score

closes https://github.com/dbeaver/pro/issues/6411