### PR TITLE
dbeaver/pro#6325 fix: set cursor to the beginning of the file when op…

### DIFF
--- a/webapp/packages/plugin-codemirror6/src/ReactCodemirror.tsx
+++ b/webapp/packages/plugin-codemirror6/src/ReactCodemirror.tsx
@@ -42,6 +42,7 @@ export const ReactCodemirror = observer<IReactCodeMirrorProps, IEditorRef>(
     ref,
   ) {
     value = value ?? getValue?.();
+    const isInitialScriptOpening = useRef(true);
     const currentExtensions = useRef<Map<Compartment, Extension>>(new Map());
     const readOnlyFacet = useMemo(() => {
       if (readonly) {
@@ -214,7 +215,7 @@ export const ReactCodemirror = observer<IReactCodeMirrorProps, IEditorRef>(
           }
         }
 
-        if (hasInsertProperty(transaction.changes) && !transaction.selection) {
+        if (hasInsertProperty(transaction.changes) && !transaction.selection && !isInitialScriptOpening.current) {
           transaction.selection = {
             anchor: transaction.changes.insert?.length ?? 0,
             head: transaction.changes.insert?.length ?? 0,
@@ -223,6 +224,7 @@ export const ReactCodemirror = observer<IReactCodeMirrorProps, IEditorRef>(
 
         if (transaction.changes) {
           view.dispatch({ changes: transaction.changes });
+          isInitialScriptOpening.current = false;
         }
 
         if (transaction.selection) {


### PR DESCRIPTION
…ened

In previous ticket CB-5555 we fixed cursor position on undo/redo actions by adding a check that if selection was not set. In that case we put the cursor to the end of inserted text. Due to previous fixes in CB-4134 we don't set a selection if cursor don't change it's position and initially it's 0. So our check from 5555 is being fired on initially opened script and cursor goes to the end.

To avoid that situation, this solution introduces a new isInitialScriptOpening flag that is used to check the first insertion.

When initially opening a script, the cursor will stay at the position where we explicitly set it (e.g., position 0). After the first actual content change, the flag isInitialScriptOpening gets set to false. Subsequent changes will then follow the normal cursor behaviour (moving to end when there are changes but no explicit cursor position).

Although this solution works well it might be better to plan to refactor cursor related logic in this hook.