### PR TITLE
[CB] Long text in the Configuration ID dropdown is not truncated and overlaps other UI elements

### DIFF
--- a/webapp/packages/core-blocks/src/FormControls/Select.tsx
+++ b/webapp/packages/core-blocks/src/FormControls/Select.tsx
@@ -146,9 +146,9 @@ export const Select: SelectType = observer(function Select({
 
   function itemRender(item: (typeof items)[number]): React.ReactNode {
     return (
-      <div className="select__item" title={item ? titleSelector?.(item) : undefined}>
+      <div className="select__item tw:truncate" title={item ? titleSelector?.(item) : undefined}>
         {renderIcon(item)}
-        <span>{valueSelector(item)}</span>
+        {valueSelector(item)}
       </div>
     );
   }

--- a/webapp/packages/core-blocks/src/ObjectPropertyInfo/ObjectPropertyInfoForm/RenderField.tsx
+++ b/webapp/packages/core-blocks/src/ObjectPropertyInfo/ObjectPropertyInfoForm/RenderField.tsx
@@ -153,6 +153,7 @@ export const RenderField = observer<RenderFieldProps>(function RenderField({
           items={property.validValues!}
           keySelector={value => value}
           valueSelector={value => value}
+          titleSelector={value => value}
           defaultValue={defaultValue}
           title={property.description}
           disabled={disabled}
@@ -172,6 +173,7 @@ export const RenderField = observer<RenderFieldProps>(function RenderField({
         items={property.validValues!}
         keySelector={value => value}
         valueSelector={value => value}
+        titleSelector={value => value}
         defaultValue={defaultValue}
         title={property.description}
         disabled={disabled}


### PR DESCRIPTION
closes https://github.com/dbeaver/pro/issues/6642

Icons in selects also seems fine without this span

https://github.com/user-attachments/assets/1dd7c6d4-a3ae-4e9f-ad8e-a385cad1116e

