### PR TITLE
dbeaver/pro#6142 fix: can't expand nodes using filter

### DIFF
--- a/webapp/packages/plugin-navigation-tree/src/TreeNew/useTreeFilter.ts
+++ b/webapp/packages/plugin-navigation-tree/src/TreeNew/useTreeFilter.ts
@@ -29,8 +29,12 @@ export function useTreeFilter(options: ITreeFilterOptions = {}): Readonly<ITreeF
   options = useObjectRef(options);
   const matchCache = new Map<string, boolean>();
 
-  function hasMatchingDescendant(
-    treeData: ITreeData, nodeId: string, filter: string, matchFn: (treeData: ITreeData, nodeId: string) => boolean): boolean {
+  function matchesOrHasMatchingDescendant(
+    treeData: ITreeData,
+    nodeId: string,
+    filter: string,
+    matchFn: (treeData: ITreeData, nodeId: string) => boolean,
+  ): boolean {
     const cacheKey = `${nodeId}:${filter}`;
     if (matchCache.has(cacheKey)) {
       return matchCache.get(cacheKey)!;
@@ -43,7 +47,7 @@ export function useTreeFilter(options: ITreeFilterOptions = {}): Readonly<ITreeF
 
     const children = treeData.getUnfilteredChildren(nodeId);
     for (const childId of children) {
-      if (hasMatchingDescendant(treeData, childId, filter, matchFn)) {
+      if (matchesOrHasMatchingDescendant(treeData, childId, filter, matchFn)) {
         matchCache.set(cacheKey, true);
         return true;
       }
@@ -94,8 +98,8 @@ export function useTreeFilter(options: ITreeFilterOptions = {}): Readonly<ITreeF
           return state;
         }
 
-        if (hasMatchingDescendant(treeData, nodeId, filter, this.isNodeMatched.bind(this))) {
-          return { ...state, expanded: true };
+        if (matchesOrHasMatchingDescendant(treeData, nodeId, filter, this.isNodeMatched.bind(this))) {
+          return { ...state };
         }
 
         return state;

--- a/webapp/packages/plugin-navigation-tree/src/TreeNew/useTreeMenu.ts
+++ b/webapp/packages/plugin-navigation-tree/src/TreeNew/useTreeMenu.ts
@@ -33,7 +33,7 @@ export function useTreeMenu(options: ITreeMenuOptions): Readonly<ITreeMenu> {
 
   const state = useObservableRef(
     () => ({
-      openMenu(event: React.MouseEvent, nodeId: string) {
+      openMenu(event: React.MouseEvent<HTMLDivElement, MouseEvent>, nodeId: string) {
         this.menu.context.deleteForId(this.id);
         this.menu.context.set(DATA_CONTEXT_NAV_NODE_ID, nodeId, this.id);
 


### PR DESCRIPTION
If folder node had not been loaded before the filter is used, we would get into situation that filtering manually expanding this node without children and we would loose the ability to load them by expanding by click(our main flow is to load on expand).

This fix removes the auto expanding on filtering. Now it works similarly to the main navigation tree with filters

https://github.com/user-attachments/assets/0bfd357a-ef65-416b-a676-6237794598b8

