### PR TITLE
dbeaver/pro#7111 fix: doubled hot keys handler

### DIFF
--- a/webapp/packages/core-view/src/View/CaptureView.tsx
+++ b/webapp/packages/core-view/src/View/CaptureView.tsx
@@ -45,7 +45,7 @@ export const CaptureView = observer<React.PropsWithChildren<ICaptureViewProps>>(
   useHotkeys(
     keys,
     (event, handler) => {
-      if (!state.reference?.contains(document.activeElement)) {
+      if (!event.isTrusted || !state.reference?.contains(document.activeElement)) {
         return;
       }
 


### PR DESCRIPTION
closes dbeaver/pro#7111