### PR TITLE
[CB] TE too many requests navNodeInfo (connection edit) which freezes interface

### DIFF
--- a/webapp/packages/plugin-connections/src/ConnectionForm/OriginInfo/ConnectionOriginInfoTabService.ts
+++ b/webapp/packages/plugin-connections/src/ConnectionForm/OriginInfo/ConnectionOriginInfoTabService.ts
@@ -40,7 +40,8 @@ export class ConnectionOriginInfoTabService extends Bootstrap {
         const key = optionsPart?.connectionKey;
 
         if (!key) {
-          throw new Error('Cannot load connection origin info: connection key is not defined');
+          console.error('Cannot load connection origin info: connection key is not defined');
+          return [];
         }
 
         return getCachedMapResourceLoaderState(this.connectionInfoOriginResource, () => key);

--- a/webapp/packages/plugin-connections/src/ConnectionForm/OriginInfo/ConnectionOriginInfoTabService.ts
+++ b/webapp/packages/plugin-connections/src/ConnectionForm/OriginInfo/ConnectionOriginInfoTabService.ts
@@ -40,7 +40,7 @@ export class ConnectionOriginInfoTabService extends Bootstrap {
         const key = optionsPart?.connectionKey;
 
         if (!key) {
-          console.error('Cannot load connection origin info: connection key is not defined');
+          console.warn('Cannot load connection origin info: connection key is not defined');
           return [];
         }
 

--- a/webapp/packages/plugin-connections/src/ConnectionForm/OriginInfo/ConnectionOriginInfoTabService.ts
+++ b/webapp/packages/plugin-connections/src/ConnectionForm/OriginInfo/ConnectionOriginInfoTabService.ts
@@ -11,7 +11,7 @@ import { Bootstrap, injectable } from '@cloudbeaver/core-di';
 
 import { ConnectionFormService } from '../ConnectionFormService.js';
 import { importLazyComponent } from '@cloudbeaver/core-blocks';
-import { CachedMapAllKey, getCachedMapResourceLoaderState } from '@cloudbeaver/core-resource';
+import { getCachedMapResourceLoaderState } from '@cloudbeaver/core-resource';
 import { getConnectionFormOptionsPart } from '../Options/getConnectionFormOptionsPart.js';
 export const ConnectionFormAuthenticationAction = importLazyComponent(() =>
   import('./ConnectionFormAuthenticationAction.js').then(m => m.ConnectionFormAuthenticationAction),
@@ -35,7 +35,16 @@ export class ConnectionOriginInfoTabService extends Bootstrap {
       order: 3,
       tab: () => OriginInfoTab,
       panel: () => OriginInfo,
-      getLoader: () => getCachedMapResourceLoaderState(this.connectionInfoOriginResource, () => CachedMapAllKey),
+      getLoader: (context, props) => {
+        const optionsPart = props?.formState ? getConnectionFormOptionsPart(props.formState) : null;
+        const key = optionsPart?.connectionKey;
+
+        if (!key) {
+          throw new Error('Cannot load connection origin info: connection key is not defined');
+        }
+
+        return getCachedMapResourceLoaderState(this.connectionInfoOriginResource, () => key);
+      },
       isHidden: (tabId, props) => {
         const optionsPart = props?.formState ? getConnectionFormOptionsPart(props.formState) : null;
         const key = optionsPart?.connectionKey;


### PR DESCRIPTION
closes https://github.com/dbeaver/pro/issues/7480

What happened:
1. `ConnectionInfoOriginResource` synced with `ConnectionInfoResource` via `this.sync(connectionInfoResource)`
2. This means `ConnectionInfoOriginResource` preloads `ConnectionInfoResource`
3. So `ConnectionInfoResource` preloaded with ALL connections
4. After the `ConnectionInfoResource` loader method has executed, it does `this.set()` for the new loaded data in the loader function
5. Which triggers `onDataUpdate` handlers, and following that, the updated data `ConnectionTree` preloads all of the connection tree leaves to match the fresh data that has  just arrived

The fix is to preload only the required connection data instead of everything.