### PR TITLE
Simple adjustment to run as non-root

### DIFF
--- a/deploy/docker/cloudbeaver-ce/Dockerfile
+++ b/deploy/docker/cloudbeaver-ce/Dockerfile
@@ -18,4 +18,8 @@ WORKDIR /opt/cloudbeaver/
 
 RUN chmod +x "run-cloudbeaver-server.sh" "/opt/cloudbeaver/launch-product.sh"
 
+RUN chown -R dbeaver:dbeaver "workspace"
+
+USER dbeaver
+
 ENTRYPOINT ["./launch-product.sh"]


### PR DESCRIPTION
This adjustment changes the user to `dbeaver` (which is already created earlier as part of the `Dockerfile`) to run the container in environments, where root access is restricted, for example Kubernetes with `securityContext.runAsNonRoot: true`.

Addresses #2290.

**Note**: I do not have full visibility in all dependencies of dbeaver/cloudbeaver so I am unsure how to test if root access is required by any component. A local test running `cloudbeaver` with these adjustments was successful.