### PR TITLE
[CB] fix contrast colors in sql editor whitespace highlight system

### DIFF
--- a/webapp/packages/plugin-codemirror6/src/theme/_base-code-editor.scss
+++ b/webapp/packages/plugin-codemirror6/src/theme/_base-code-editor.scss
@@ -31,8 +31,15 @@
     @include mdc-theme-prop(border-color, background, false);
   }
 
+  .editor .cm-highlightTab {
+    opacity: 0.3;
+    color: var(--theme-text-hint-on-light);
+    pointer-events: none;
+  }
+
   .editor .cm-newline {
     color: var(--theme-text-hint-on-light);
+    opacity: 0.3;
     margin-left: 4px;
     cursor: default;
     pointer-events: none;
@@ -40,6 +47,7 @@
 
   .editor .cm-highlightSpace {
     background-image: radial-gradient(circle at 50% 55%, var(--theme-text-hint-on-light) 15%, transparent 5%);
+    opacity: 0.3;
     background-position: center;
   }
 

--- a/webapp/packages/plugin-codemirror6/src/theme/_base-code-editor.scss
+++ b/webapp/packages/plugin-codemirror6/src/theme/_base-code-editor.scss
@@ -32,14 +32,14 @@
   }
 
   .editor .cm-highlightTab {
-    opacity: 0.3;
+    opacity: 0.6;
     color: var(--theme-text-hint-on-light);
     pointer-events: none;
   }
 
   .editor .cm-newline {
     color: var(--theme-text-hint-on-light);
-    opacity: 0.3;
+    opacity: 0.6;
     margin-left: 4px;
     cursor: default;
     pointer-events: none;
@@ -47,7 +47,7 @@
 
   .editor .cm-highlightSpace {
     background-image: radial-gradient(circle at 50% 55%, var(--theme-text-hint-on-light) 15%, transparent 5%);
-    opacity: 0.3;
+    opacity: 0.6;
     background-position: center;
   }
 


### PR DESCRIPTION
closes https://github.com/dbeaver/pro/issues/8055

~How it become:~ Previous implementation with opacity 0.3:
<img width="512" height="187" alt="Screenshot 2026-01-19 at 10 40 10" src="https://github.com/user-attachments/assets/d8a56ec6-862c-42d1-a5b2-96a7767e37ce" />
<img width="483" height="202" alt="Screenshot 2026-01-19 at 10 41 01" src="https://github.com/user-attachments/assets/6d5def32-641e-45da-9ac3-183d4e4b17fb" />

Current implementation:
<img width="598" height="222" alt="Screenshot 2026-01-19 at 13 48 17" src="https://github.com/user-attachments/assets/24c86747-cae7-4f1a-9d50-b8ca3a61c089" />
<img width="635" height="187" alt="Screenshot 2026-01-19 at 13 48 35" src="https://github.com/user-attachments/assets/1036492b-3958-4e1b-9eaa-9718711ad6fd" />

