### PR TITLE
[CB] Decrize the size of radio buttons

### DIFF
--- a/webapp/common-react/@dbeaver/ui-kit/src/Checkbox/Checkbox.css
+++ b/webapp/common-react/@dbeaver/ui-kit/src/Checkbox/Checkbox.css
@@ -33,6 +33,7 @@
 
   .dbv-kit-checkbox__check {
     --check-size: round(calc(var(--dbv-kit-checkbox-height) * var(--dbv-kit-checkbox-check-size)), 2px);
+    margin-top: calc(var(--dbv-kit-checkbox-height) * (calc(1 - var(--dbv-kit-checkbox-check-size)) / 2));
     height: var(--check-size);
     line-height: var(--check-size);
     width: var(--check-size);

--- a/webapp/common-react/@dbeaver/ui-kit/src/Checkbox/Checkbox.css
+++ b/webapp/common-react/@dbeaver/ui-kit/src/Checkbox/Checkbox.css
@@ -33,7 +33,6 @@
 
   .dbv-kit-checkbox__check {
     --check-size: round(calc(var(--dbv-kit-checkbox-height) * var(--dbv-kit-checkbox-check-size)), 2px);
-    margin-top: calc(var(--dbv-kit-checkbox-height) * (calc(1 - var(--dbv-kit-checkbox-check-size)) / 2));
     height: var(--check-size);
     line-height: var(--check-size);
     width: var(--check-size);

--- a/webapp/common-react/@dbeaver/ui-kit/src/Radio/Radio.css
+++ b/webapp/common-react/@dbeaver/ui-kit/src/Radio/Radio.css
@@ -86,7 +86,7 @@
     height: var(--ring-size);
     margin-top: calc((var(--dbv-kit-radio-height) - (var(--ring-size))) * 0.5);
     border-radius: 50%;
-    border: 2px solid var(--dbv-kit-radio-inactive-border);
+    border: var(--dbv-kit-radio-border-width) solid var(--dbv-kit-radio-inactive-border);
     background-color: var(--dbv-kit-radio-inactive-background);
 
     @media (prefers-reduced-motion: no-preference) {

--- a/webapp/common-react/@dbeaver/ui-kit/src/Radio/_base.css
+++ b/webapp/common-react/@dbeaver/ui-kit/src/Radio/_base.css
@@ -15,6 +15,7 @@
     --dbv-kit-radio-dot-size: 0.25;
     --dbv-kit-radio-font-size: calc(var(--dbv-kit-font-size-base) * 0.875);
     --dbv-kit-radio-gap: var(--tw-spacing);
+    --dbv-kit-radio-border-width: 1px;
 
     --dbv-kit-select-label-foreground: var(--dbv-kit-color-control-label);
     --dbv-kit-select-label-padding-inline: var(--tw-spacing);

--- a/webapp/packages/core-blocks/src/FormControls/Radio.css
+++ b/webapp/packages/core-blocks/src/FormControls/Radio.css
@@ -9,10 +9,11 @@
 @layer components {
   :root {
     --dbv-kit-radio-small-height: 24px;
-    --dbv-kit-radio-small-gap: calc(var(--dbv-kit-radio-gap) * 0.25);
+    --dbv-kit-radio-medium-height: 28px;
+    --dbv-kit-radio-large-height: 32px;
+    --dbv-kit-radio-xlarge-height: 36px;
 
     --dbv-kit-radio-medium-dot-size: 0.3;
-    --dbv-kit-radio-medium-height: 32px;
     --dbv-kit-radio-medium-gap: calc(var(--dbv-kit-radio-gap) * 3);
   }
 

--- a/webapp/packages/core-blocks/src/FormControls/Radio.css
+++ b/webapp/packages/core-blocks/src/FormControls/Radio.css
@@ -24,7 +24,7 @@
     --dbv-kit-radio-active-border: var(--theme-primary);
     --dbv-kit-radio-active-foreground: var(--theme-primary);
 
-    --dbv-kit-radio-inactive-border: color-mix(in srgb, var(--theme-on-secondary), white 30%);
+    --dbv-kit-radio-inactive-border: color-mix(in srgb, var(--theme-on-secondary), white 20%);
     --dbv-kit-radio-hover-shadow-color: color-mix(in srgb, var(--theme-on-secondary), white 80%);
   }
 


### PR DESCRIPTION
closes https://github.com/dbeaver/pro/issues/8202

I also matched colors. For radio, it was a little brighter

idk seems fine to me

<img width="402" height="302" alt="Screenshot 2026-02-03 at 16 38 26" src="https://github.com/user-attachments/assets/5c4e4af1-2bee-4256-b12d-a5bcfee2b80b" />

<img width="215" height="230" alt="Screenshot 2026-02-03 at 16 38 40" src="https://github.com/user-attachments/assets/272e0e26-acb2-447f-a6c2-c5c8fd90b5e5" />

<img width="1295" height="890" alt="Screenshot 2026-02-03 at 16 38 50" src="https://github.com/user-attachments/assets/4b3c0cc6-59bd-47b3-a372-a306077541e6" />

<img width="686" height="878" alt="Screenshot 2026-02-03 at 16 39 06" src="https://github.com/user-attachments/assets/f92e4154-8ae1-47c2-bfc6-ed0ce9822d06" />

<img width="1125" height="1019" alt="Screenshot 2026-02-03 at 16 39 24" src="https://github.com/user-attachments/assets/09707370-0b55-4af4-a735-63217faf847b" />

<img width="959" height="479" alt="Screenshot 2026-02-03 at 16 39 58" src="https://github.com/user-attachments/assets/3387c10e-3763-4318-832b-59d0d861e1a8" />
