### PR TITLE
dbeaver/pro#8808 feat: add shortcut for search in data viewer

### DIFF
--- a/webapp/packages/plugin-help/src/Shortcuts/SHORTCUTS_DATA.ts
+++ b/webapp/packages/plugin-help/src/Shortcuts/SHORTCUTS_DATA.ts
@@ -33,8 +33,8 @@ const KEY_BINDING_SQL_EDITOR_COMMENT = createKeyBinding({
   keys: ['mod+/'],
 });
 
-const KEY_BINDING_SQL_EDITOR_FIND = createKeyBinding({
-  id: 'sql-editor-find',
+const KEY_BINDING_FIND = createKeyBinding({
+  id: 'plugin-search-panel-find',
   keys: ['mod+f'],
 });
 
@@ -56,6 +56,10 @@ export const DATA_VIEWER_SHORTCUTS: IShortcut[] = [
   {
     label: 'data_viewer_shortcut_delete_row',
     code: transformKeys(KEY_BINDING_DELETE_ROW),
+  },
+  {
+    label: 'plugin_search_panel_find',
+    code: transformKeys(KEY_BINDING_FIND),
   },
   {
     label: 'ui_processing_save',
@@ -109,8 +113,8 @@ export const SQL_EDITOR_SHORTCUTS: IShortcut[] = [
     code: transformKeys(KEY_BINDING_REDO),
   },
   {
-    label: 'sql_editor_shortcut_find',
-    code: transformKeys(KEY_BINDING_SQL_EDITOR_FIND),
+    label: 'plugin_search_panel_find',
+    code: transformKeys(KEY_BINDING_FIND),
   },
   {
     label: 'sql_editor_shortcut_comment_uncomment_selection',

--- a/webapp/packages/plugin-help/src/Shortcuts/SHORTCUTS_DATA.ts
+++ b/webapp/packages/plugin-help/src/Shortcuts/SHORTCUTS_DATA.ts
@@ -34,7 +34,7 @@ const KEY_BINDING_SQL_EDITOR_COMMENT = createKeyBinding({
 });
 
 const KEY_BINDING_FIND = createKeyBinding({
-  id: 'plugin-search-panel-find',
+  id: 'find',
   keys: ['mod+f'],
 });
 

--- a/webapp/packages/plugin-help/src/locales/en.ts
+++ b/webapp/packages/plugin-help/src/locales/en.ts
@@ -18,11 +18,12 @@ export default [
   ['sql_editor_shortcut_show_execution_plan', 'Show Execution plan'],
   ['sql_editor_shortcut_format', 'Format script'],
   ['sql_editor_shortcut_open_editor_in_new_tab', 'Open SQL Editor in the separate browser Tab'],
-  ['sql_editor_shortcut_find', 'Find'],
   ['sql_editor_shortcut_comment_uncomment_selection', 'Comment/Uncomment selection'],
   ['sql_editor_shortcut_start_completion', 'Show autocomplete suggestions'],
   ['sql_editor_shortcut_accept_completion', 'Accept autocompletion'],
   ['sql_editor_shortcut_escape', 'Escape editor'],
+
+  ['plugin_search_panel_find', 'Find'],
 
   ['navigation_tree_shortcut_enable_filter', 'Enable filtering'],
 
@@ -34,5 +35,5 @@ export default [
   Your local application settings will be lost after the browser tab is closed.
   You can load tabs and settings for this tab`,
   ],
-  ['plugin_help_multi_tab_support_load_settings', 'Load tabs ans settings'],
+  ['plugin_help_multi_tab_support_load_settings', 'Load tabs and settings'],
 ];

--- a/webapp/packages/plugin-help/src/locales/fr.ts
+++ b/webapp/packages/plugin-help/src/locales/fr.ts
@@ -17,16 +17,16 @@ export default [
   ['sql_editor_shortcut_show_execution_plan', "Afficher le plan d'exécution"],
   ['sql_editor_shortcut_format', 'Formater le script'],
   ['sql_editor_shortcut_open_editor_in_new_tab', "Ouvrir l'éditeur SQL dans un nouvel onglet"],
-  ['sql_editor_shortcut_find', 'Rechercher'],
   ['sql_editor_shortcut_comment_uncomment_selection', 'Commenter/Décommenter la sélection'],
   ['sql_editor_shortcut_start_completion', 'Afficher les suggestions de saisie semi-automatique'],
   ['sql_editor_shortcut_accept_completion', 'Accepter la saisie semi-automatique'],
   ['sql_editor_shortcut_escape', "Échapper l'éditeur"],
+  ['plugin_search_panel_find', 'Rechercher'],
   ['navigation_tree_shortcut_enable_filter', 'Activer le filtrage'],
   ['plugin_help_multi_tab_support_title', "Le multi-onglet n'est pas supporté"],
   [
     'plugin_help_multi_tab_support_description',
     "Les données ne sont pas connectées à d'autres onglets du navigateur. Tout onglet d'application ouvert ne sera pas sauvegardé et sera probablement perdu après la fermeture de l'onglet. Vos paramètres et données locaux seront perdus après la fermeture de l'onglet. Vous pouvez charger les onglets et les paramètres pour cet onglet.",
   ],
-  ['plugin_help_multi_tab_support_load_settings', 'Charger les onglets comme paramètres'],
+  ['plugin_help_multi_tab_support_load_settings', 'Charger les onglets et les paramètres'],
 ];

--- a/webapp/packages/plugin-help/src/locales/it.ts
+++ b/webapp/packages/plugin-help/src/locales/it.ts
@@ -18,11 +18,11 @@ export default [
   ['sql_editor_shortcut_show_execution_plan', 'Show Execution plan'],
   ['sql_editor_shortcut_format', 'Format script'],
   ['sql_editor_shortcut_open_editor_in_new_tab', 'Open SQL Editor in the separate browser Tab'],
-  ['sql_editor_shortcut_find', 'Find'],
   ['sql_editor_shortcut_comment_uncomment_selection', 'Comment/Uncomment selection'],
   ['sql_editor_shortcut_start_completion', 'Show autocomplete suggestions'],
   ['sql_editor_shortcut_accept_completion', 'Accept autocompletion'],
   ['sql_editor_shortcut_escape', 'Escape editor'],
+  ['plugin_search_panel_find', 'Find'],
 
   ['navigation_tree_shortcut_enable_filter', 'Enable filtering'],
 ];

--- a/webapp/packages/plugin-help/src/locales/ru.ts
+++ b/webapp/packages/plugin-help/src/locales/ru.ts
@@ -18,11 +18,11 @@ export default [
   ['sql_editor_shortcut_show_execution_plan', 'Показать план выполнения'],
   ['sql_editor_shortcut_format', 'Форматировать скрипт'],
   ['sql_editor_shortcut_open_editor_in_new_tab', 'Открыть SQL редактор в новой бразуерной вкладке'],
-  ['sql_editor_shortcut_find', 'Найти'],
   ['sql_editor_shortcut_comment_uncomment_selection', 'Закомментировать/раскомментировать выделение'],
   ['sql_editor_shortcut_start_completion', 'Показать подсказки автодополнения'],
   ['sql_editor_shortcut_accept_completion', 'Принять автодополнение'],
   ['sql_editor_shortcut_escape', 'Выйти из редактора'],
+  ['plugin_search_panel_find', 'Найти'],
 
   ['navigation_tree_shortcut_enable_filter', 'Включить фильтрацию'],
 ];

--- a/webapp/packages/plugin-help/src/locales/vi.ts
+++ b/webapp/packages/plugin-help/src/locales/vi.ts
@@ -18,11 +18,11 @@ export default [
   ['sql_editor_shortcut_show_execution_plan', 'Hiển thị kế hoạch thực thi'],
   ['sql_editor_shortcut_format', 'Định dạng kịch bản'],
   ['sql_editor_shortcut_open_editor_in_new_tab', 'Mở Trình chỉnh sửa SQL trong tab riêng biệt'],
-  ['sql_editor_shortcut_find', 'Tìm kiếm'],
   ['sql_editor_shortcut_comment_uncomment_selection', 'Bình luận/Bỏ bình luận lựa chọn'],
   ['sql_editor_shortcut_start_completion', 'Hiển thị gợi ý tự động hoàn thành'],
   ['sql_editor_shortcut_accept_completion', 'Chấp nhận tự động hoàn thành'],
   ['sql_editor_shortcut_escape', 'Thoát khỏi trình chỉnh sửa'],
+  ['plugin_search_panel_find', 'Tìm kiếm'],
 
   ['navigation_tree_shortcut_enable_filter', 'Bật lọc'],
 

--- a/webapp/packages/plugin-help/src/locales/zh.ts
+++ b/webapp/packages/plugin-help/src/locales/zh.ts
@@ -18,11 +18,11 @@ export default [
   ['sql_editor_shortcut_show_execution_plan', '显示执行计划'],
   ['sql_editor_shortcut_format', '格式化脚本'],
   ['sql_editor_shortcut_open_editor_in_new_tab', '在单独的浏览器标签下打开SQL编辑器'],
-  ['sql_editor_shortcut_find', '查找'],
   ['sql_editor_shortcut_comment_uncomment_selection', '注释/取消注释所选内容'],
   ['sql_editor_shortcut_start_completion', '显示自动完成建议'],
   ['sql_editor_shortcut_accept_completion', '接受自动完成'],
   ['sql_editor_shortcut_escape', '退出编辑器'],
+  ['plugin_search_panel_find', '查找'],
 
   ['navigation_tree_shortcut_enable_filter', '启用过滤'],
 ];


### PR DESCRIPTION
<img width="722" height="450" alt="image" src="https://github.com/user-attachments/assets/92fea6dc-5064-4855-ba2d-7acba29fdc97" />

Since this `sql_editor_shortcut_find ` is basically only used for shortcuts, I decided to reuse it for data viewer. It uses the same component, shortcut etc.