### PR TITLE
dbeaver/pro#8805 do not move focus on programmatic tab select

### DIFF
--- a/webapp/packages/core-ui/src/Tabs/TabsState.tsx
+++ b/webapp/packages/core-ui/src/Tabs/TabsState.tsx
@@ -125,7 +125,7 @@ export const TabsState = observer(function TabsState<T = Record<string, any>>({
       const tabExists = isNotNullDefined(selectedId) && displayed.includes(selectedId);
 
       if (!tabExists) {
-        dynamic.store.select(displayed[0]);
+        dynamic.store.setSelectedId(displayed[0]);
       }
     }
   }, [displayed, autoSelect]);
@@ -141,7 +141,7 @@ export const TabsState = observer(function TabsState<T = Record<string, any>>({
         }
         dynamic.selectedId = data.tabId;
         if (dynamic.store.getState().selectedId !== data.tabId) {
-          dynamic.store.select(data.tabId);
+          dynamic.store.setSelectedId(data.tabId);
         }
       },
     ],


### PR DESCRIPTION
closes [8805](https://github.com/dbeaver/pro/issues/8805)

we do not move focus on programmatic select to keep it align with initial behaviour
https://ariakit.com/reference/use-tab-store#setselectedid-1