### PR TITLE
dbeaver/pro#9132 use closest instead of current

### DIFF
--- a/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/useGridSelectedCellsCopy.ts
+++ b/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/useGridSelectedCellsCopy.ts
@@ -78,13 +78,18 @@ export function useGridSelectedCellsCopy(
   const onKeydownHandler = useCallback((event: React.KeyboardEvent) => {
     if ((event.ctrlKey || event.metaKey) && event.nativeEvent.code === EVENT_KEY_CODE.C) {
       const activeElement = document.activeElement as HTMLElement | null;
-      if (
-        activeElement?.getAttribute('role') !== 'gridcell' &&
-        activeElement?.getAttribute('role') !== 'columnheader' &&
-        event.target !== event.currentTarget
-      ) {
+      const isEditing = activeElement?.matches('input, textarea, [contenteditable="true"]');
+
+      if(isEditing) {
         return;
       }
+
+      const hasTarget = activeElement?.closest('[role="gridcell"], [role="columnheader"]') !== null;
+
+      if (!hasTarget && event.target !== event.currentTarget) {
+        return;
+      }
+
       EventContext.set(event, EventStopPropagationFlag);
 
       if (dataViewerService.canCopyData) {


### PR DESCRIPTION
closes [9132](https://github.com/dbeaver/pro/issues/9132)

When the boolean formatter is focused, the active element does not have the required role, so I changed it to the closest match. To prevent regression related to the ticket below, we now also check for the editing attribute to avoid triggering copy when the user is editing a value.

https://dbeaver.atlassian.net/browse/CB-4699