### PR TITLE
dbeaver/cloudbeaver#4138 feat: support inline editing of multi-line v…

### DIFF
--- a/webapp/common-react/@dbeaver/react-data-grid/src/editors/TextEditor.module.css
+++ b/webapp/common-react/@dbeaver/react-data-grid/src/editors/TextEditor.module.css
@@ -1,5 +1,6 @@
 :global(.rdg-cell) .editor {
   appearance: none;
+  resize: none;
 
   box-sizing: border-box;
   min-height: initial;

--- a/webapp/common-react/@dbeaver/react-data-grid/src/editors/TextEditor.tsx
+++ b/webapp/common-react/@dbeaver/react-data-grid/src/editors/TextEditor.tsx
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -11,9 +11,22 @@ import classes from './TextEditor.module.css';
 import { DataGridCellContext } from '../DataGridCellContext.js';
 import { useGridReactiveValue } from '../useGridReactiveValue.js';
 
-function autoFocusAndSelect(input: HTMLInputElement | null) {
-  input?.focus();
-  input?.select();
+function autoFocusAndSelect(input: HTMLTextAreaElement | null) {
+  if (!input) {
+    return;
+  }
+  input.focus();
+  input.select();
+
+  input.addEventListener(
+    'beforeinput',
+    e => {
+      if (e.inputType === 'insertLineBreak') {
+        e.preventDefault();
+      }
+    },
+    { once: true },
+  );
 }
 
 export interface IProps {
@@ -28,9 +41,10 @@ export function TextEditor({ rowIdx, colIdx, onClose }: IProps) {
   const value = useGridReactiveValue(cellContext?.cellText, rowIdx, colIdx) ?? '';
 
   return (
-    <input
-      className={classes['editor']}
+    <textarea
       ref={autoFocusAndSelect}
+      className={classes['editor']}
+      rows={1}
       value={value}
       onChange={event => cellContext?.onCellChange?.(rowIdx, colIdx, event.target.value)}
       onBlur={() => onClose()}

--- a/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/Formatters/CellFormatters/TextFormatter.tsx
+++ b/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/Formatters/CellFormatters/TextFormatter.tsx
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ export const TextFormatter = observer<ICellFormatterProps>(function TextFormatte
   const classes = s(style, { textFormatter: true });
 
   return (
-    <div title={displayValue} className={classes}>
+    <div title={textValue} className={classes}>
       {isValidUrl(textValue) && (
         <a href={textValue} target="_blank" rel="noreferrer" draggable={false} className={s(style, { a: true })}>
           <IconOrImage icon="external-link" viewBox="0 0 24 24" className={s(style, { icon: true })} />

--- a/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/useGridSelectedCellsPaste.ts
+++ b/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/useGridSelectedCellsPaste.ts
@@ -60,6 +60,16 @@ export function useGridSelectedCellsPaste(
         return;
       }
 
+      if (selectedCells.length === 1) {
+        const [target] = selectedCells;
+
+        if (target && tableData.isCellEditable(target)) {
+          tableData.editor.set(target, clipboardText);
+        }
+
+        return;
+      }
+
       const matrix = parseTSV(clipboardText);
       const rows = matrix.length;
       const cols = matrix[0]?.length ?? 0;

--- a/webapp/packages/plugin-data-viewer/src/DatabaseDataModel/Actions/ResultSet/ResultSetFormatAction.ts
+++ b/webapp/packages/plugin-data-viewer/src/DatabaseDataModel/Actions/ResultSet/ResultSetFormatAction.ts
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -322,10 +322,19 @@ export class ResultSetFormatAction
   }
 
   truncateText(text: string, length: number): string {
-    return text
-      .slice(0, length)
-      .split('')
-      .map(v => (v.charCodeAt(0) < 32 ? ' ' : v))
-      .join('');
+    // \p{Cc} Unicode "Other, Control" category. \r\n together for Windows newlines
+    return text.slice(0, length).replace(/\r\n|\p{Cc}/gu, ch => {
+      switch (ch) {
+        case '\r\n':
+        case '\n':
+          return '↵';
+        case '\r':
+          return '␍';
+        case '\t':
+          return '→';
+        default:
+          return ' ';
+      }
+    });
   }
 }


### PR DESCRIPTION
…alues in data grid cells

- TextEditor: switch <input> to <textarea rows=1> so newlines are preserved when editing. Suppress the trailing insertLineBreak from the Enter that opens the editor (would otherwise wipe the auto-selected value).
- ResultSetFormatAction.truncateText: substitute \n, \r, \r\n, \t with visible glyphs (↵, ␍, →) and collapse other control chars to a space in a single pass.

Perf note: the new replace should be faster than the prior split('') + map + join. No intermediate array allocations, and the callback runs only on matched chars (which are sparse in display text). \p{Cc} also expands coverage from charCode < 32 to include DEL and C1 controls (U+007F, U+0080–U+009F). (closer to Dbeaver behavior)