### PR TITLE
dbeaver/pro#9095 load active connections before checking execution co…

### DIFF
--- a/webapp/packages/plugin-sql-editor-navigation-tab/src/SqlEditorTabService.ts
+++ b/webapp/packages/plugin-sql-editor-navigation-tab/src/SqlEditorTabService.ts
@@ -314,11 +314,11 @@ export class SqlEditorTabService extends Bootstrap {
     }
 
     const dataSource = this.sqlDataSourceService.create(tab.handlerState, tab.handlerState.datasourceKey);
+
+    await this.connectionInfoResource.load(ConnectionInfoActiveProjectKey);
     const executionContext = dataSource.executionContext;
 
     if (executionContext) {
-      await this.connectionInfoResource.load(ConnectionInfoActiveProjectKey);
-
       const contextConnection = createConnectionParam(executionContext.projectId, executionContext.connectionId);
 
       if (!this.connectionInfoResource.has(contextConnection)) {


### PR DESCRIPTION
closes [9095](https://github.com/dbeaver/pro/issues/9095)

Some of the data sources return an execution context only if a connection exists at the resource level (datasets, resources, file system, etc.). If no one in the app has loaded the connection, the execution context will always be undefined.

```
 get executionContext(): IConnectionExecutionContextInfo | undefined {
    if (
      !this.state.executionContext ||
      !this.connectionInfoResource.has(createConnectionParam(this.state.executionContext.projectId, this.state.executionContext.connectionId))
    ) {
      return undefined;
    }
    return this.state.executionContext;
  }
```

Since datasets are restored at the SQL tab level, I moved the load function up so that we load the connection before checking the execution context. This ensures that the restore process works as expected without side effects from the app.

The only downside is that if every sql tab lacks an execution context, we will load the active project connections. However, this scenario is very unlikely as it would require the UI to be in the VIEWER role (and there datasets have connections anyway), where only the restore behavior load connections (we dont have top bar actions, navigation tree and etc)