### PR TITLE
dbeaver/pro#9407 fix: long values wrapping

### DIFF
--- a/webapp/common-react/@dbeaver/react-data-grid/src/editors/TextEditor.module.css
+++ b/webapp/common-react/@dbeaver/react-data-grid/src/editors/TextEditor.module.css
@@ -1,6 +1,13 @@
 :global(.rdg-cell) .editor {
   appearance: none;
   resize: none;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   box-sizing: border-box;
   min-height: initial;

--- a/webapp/common-react/@dbeaver/react-data-grid/src/editors/TextEditor.tsx
+++ b/webapp/common-react/@dbeaver/react-data-grid/src/editors/TextEditor.tsx
@@ -45,6 +45,7 @@ export function TextEditor({ rowIdx, colIdx, onClose }: IProps) {
       ref={autoFocusAndSelect}
       className={classes['editor']}
       rows={1}
+      wrap="off"
       value={value}
       onChange={event => cellContext?.onCellChange?.(rowIdx, colIdx, event.target.value)}
       onBlur={() => onClose()}


### PR DESCRIPTION
we mimic here the old input's behaviour, when we can't see the scroll but can navigate through the 1-line value with keyboard or mouse drag/selection


https://github.com/user-attachments/assets/35c7772f-0cd7-45a0-aa3a-8ac13f31bfc2

