### PR TITLE
dbeaver/pro#7548 fixes "load more" button for main nodes

### DIFF
--- a/webapp/packages/core-navigation-tree/src/NodesManager/NavTreeResource.ts
+++ b/webapp/packages/core-navigation-tree/src/NodesManager/NavTreeResource.ts
@@ -87,7 +87,7 @@ export class NavTreeResource extends CachedMapResource<string, string[], Record<
     private readonly sessionDataResource: SessionDataResource,
     private readonly userInfoResource: UserInfoResource,
     private readonly projectInfoResource: ProjectInfoResource,
-    appAuthService: AppAuthService,
+    private readonly appAuthService: AppAuthService,
   ) {
     super();
 
@@ -119,7 +119,13 @@ export class NavTreeResource extends CachedMapResource<string, string[], Record<
       () => CachedMapAllKey,
       () => CachedMapAllKey,
     );
-    this.projectInfoResource.onDataOutdated.addHandler(() => this.markTreeOutdated(resourceKeyList(this.keys)));
+    this.projectInfoResource.onDataOutdated.addHandler(data => {
+      if (isResourceAlias(data)) {
+        return;
+      } else {
+        this.markTreeOutdated(data);
+      }
+    });
     this.sessionDataResource.onDataOutdated.addHandler(() => this.markTreeOutdated(resourceKeyList(this.keys)));
     this.userInfoResource.onUserChange.addHandler(
       action(() => {
@@ -551,7 +557,7 @@ export class NavTreeResource extends CachedMapResource<string, string[], Record<
     return nestedChildren;
   }
 
-  private setNavObject(data: NavNodeChildrenQuery | NavNodeChildrenQuery[], offset: number, limit: number): void {
+  private setNavObject(data: NavNodeChildrenQuery | NavNodeChildrenQuery[], offset: number, limit: number | undefined): void {
     if (Array.isArray(data)) {
       if (data.length === 0) {
         return;
@@ -589,12 +595,12 @@ export class NavTreeResource extends CachedMapResource<string, string[], Record<
     }
   }
 
-  private insertSlice(data: NavNodeChildrenQuery, offset: number, limit: number): string[] {
+  private insertSlice(data: NavNodeChildrenQuery, offset: number, limit: number | undefined): string[] {
     let children = [...(this.get(data.parentPath) || [])];
 
-    children.splice(offset, limit, ...data.navNodeChildren.map(node => node.uri));
+    children.splice(offset, limit ?? children.length, ...data.navNodeChildren.map(node => node.uri));
 
-    if (data.navNodeChildren.length < limit) {
+    if (limit !== undefined && data.navNodeChildren.length < limit) {
       children.splice(offset + data.navNodeChildren.length, children.length - offset - data.navNodeChildren.length);
     }
 
@@ -603,7 +609,36 @@ export class NavTreeResource extends CachedMapResource<string, string[], Record<
     return children;
   }
 
-  private async loadNodeChildren(parentPath: string, offset: number, limit: number): Promise<NavNodeChildrenQuery> {
+  async loadAllChildren(nodeId: string): Promise<void> {
+    if (!this.appAuthService.authenticated || this.isLoading(nodeId)) {
+      return;
+    }
+
+    const pageKey = CachedResourceOffsetPageKey(0, 0).setParent(CachedResourceOffsetPageTargetKey(nodeId));
+    const hasPage = this.offsetPagination.getPageInfo(pageKey) !== undefined;
+
+    if (hasPage && !this.isOutdated(nodeId)) {
+      return;
+    }
+
+    this.markLoading(nodeId, true);
+    try {
+      const navNodeChildren = await this.loadNodeChildren(nodeId, 0, undefined);
+      const uris = navNodeChildren.navNodeChildren.map(node => node.uri);
+
+      runInAction(() => {
+        this.setNavObject(navNodeChildren, 0, undefined);
+        this.offsetPagination.setPage(CachedResourceOffsetPageKey(0, uris.length).setParent(CachedResourceOffsetPageTargetKey(nodeId)), uris, false);
+        this.markLoaded(nodeId);
+        this.markUpdated(nodeId);
+        this.markUpdated(resourceKeyList(uris));
+      });
+    } finally {
+      this.markLoading(nodeId, false);
+    }
+  }
+
+  private async loadNodeChildren(parentPath: string, offset: number, limit: number | undefined): Promise<NavNodeChildrenQuery> {
     const metadata = this.metadata.get(parentPath);
     const { navNodeChildren, navNodeInfo } = await this.graphQLService.sdk.navNodeChildren({
       parentPath,

--- a/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/useElementsTree.ts
+++ b/webapp/packages/plugin-navigation-tree/src/NavigationTree/ElementsTree/useElementsTree.ts
@@ -233,8 +233,9 @@ export function useElementsTree(options: IOptions): IElementsTree {
       const pageInfo = navTreeResource.offsetPagination.getPageInfo(
         CachedResourceOffsetPageKey(0, 0).setParent(CachedResourceOffsetPageTargetKey(nodeId)),
       );
+      const hasMorePages = pageInfo && pageInfo.end === undefined;
 
-      if (pageInfo) {
+      if (hasMorePages) {
         const lastOffset = getNextPageOffset(pageInfo);
         for (let offset = 0; offset < lastOffset; offset += navTreeResource.childrenLimit) {
           await navTreeResource.load(

--- a/webapp/packages/plugin-navigation-tree/src/NavigationTree/NavigationTreeService.ts
+++ b/webapp/packages/plugin-navigation-tree/src/NavigationTree/NavigationTreeService.ts
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,14 @@ import {
 } from '@cloudbeaver/core-connections';
 import { injectable } from '@cloudbeaver/core-di';
 import { Executor, type IExecutor, type ISyncExecutor, SyncExecutor } from '@cloudbeaver/core-executor';
-import { EObjectFeature, NavNodeInfoResource, NavNodeManagerService, NavTreeResource, ROOT_NODE_PATH } from '@cloudbeaver/core-navigation-tree';
+import {
+  EObjectFeature,
+  NavNodeInfoResource,
+  NavNodeManagerService,
+  NavTreeResource,
+  ProjectsNavNodeService,
+  ROOT_NODE_PATH,
+} from '@cloudbeaver/core-navigation-tree';
 import {
   CACHED_RESOURCE_DEFAULT_PAGE_OFFSET,
   CachedResourceOffsetPageKey,
@@ -46,6 +53,7 @@ interface INavigationNodeShowData {
   NavNodeExtensionsService,
   NavNodeInfoResource,
   NavTreeResource,
+  ProjectsNavNodeService,
 ])
 export class NavigationTreeService extends View<string> {
   readonly treeState: MetadataMap<string, ITreeNodeState>;
@@ -59,6 +67,7 @@ export class NavigationTreeService extends View<string> {
     private readonly navNodeExtensionsService: NavNodeExtensionsService,
     private readonly navNodeInfoResource: NavNodeInfoResource,
     private readonly navTreeResource: NavTreeResource,
+    private readonly projectsNavNodeService: ProjectsNavNodeService,
   ) {
     super();
 
@@ -131,11 +140,15 @@ export class NavigationTreeService extends View<string> {
       return false;
     }
 
-    await this.navTreeResource.load(
-      CachedResourceOffsetPageKey(CACHED_RESOURCE_DEFAULT_PAGE_OFFSET, this.navTreeResource.childrenLimit).setParent(
-        CachedResourceOffsetPageTargetKey(id),
-      ),
-    );
+    if (this.isMainNode(id)) {
+      await this.navTreeResource.loadAllChildren(id);
+    } else {
+      await this.navTreeResource.load(
+        CachedResourceOffsetPageKey(CACHED_RESOURCE_DEFAULT_PAGE_OFFSET, this.navTreeResource.childrenLimit).setParent(
+          CachedResourceOffsetPageTargetKey(id),
+        ),
+      );
+    }
 
     return true;
   }
@@ -192,6 +205,18 @@ export class NavigationTreeService extends View<string> {
       id: resourceKeyList(list),
       selected: list.map(() => false),
     });
+  }
+
+  // Main nodes - root, project, file system (dbvfs), scripts or datasets (rm)
+  private isMainNode(id: string): boolean {
+    if (id === ROOT_NODE_PATH) {
+      return true;
+    }
+    const node = this.navNodeInfoResource.get(id);
+    if (!node) {
+      return false;
+    }
+    return node.parentId === ROOT_NODE_PATH || this.projectsNavNodeService.projectTypes.includes(node.nodeType ?? '');
   }
 
   private isConnectionNode(navNodeId: string) {


### PR DESCRIPTION
closes https://github.com/dbeaver/pro/issues/7548

The pagination mechanism works perfectly fine. The main issue is that we have what I would call "main" nodes and their children.

Examples of "main" nodes include: `node://`, `node://rm`, `node://dbvfs`, `node://projectId`, etc. Basically, these are all nodes that contain the trees of child nodes displayed in the tree view.

The pagination mechanism, with a limit configurable in the settings, applies to all of these nodes.

The problem occurs during the initial page load. The application loads the "main" nodes using the configured pagination limit. For example, if the limit is set to 10 items per page and there are 100 projects in the TE product, only the first 10 projects are loaded on startup. A "Load more" button is then displayed.

However, the currently selected project may be outside the loaded range (for example, project #82 out of 100). In that case, the user has to click "Load more" repeatedly until the page containing the selected project is loaded.

This mechanism works well for non-main nodes (i.e., child nodes). However, I propose loading all "main" nodes during initialization so that the application is aware of all available root-level items from the start. We can still use "Load more" for loading additional information related to those "main" nodes.

In summary, this PR introduces eager loading of all "main" nodes when tree loading is triggered (for any tree: connections, scripts, datasets, cloud storage, etc.). All other nodes continue to be handled exactly as they were before this PR.

Additionally, I added several optimizations to the page-loading process to reduce the number of network requests. The overall traffic remains the same, and I haven't noticed any artifacts or unexpected behavior during testing.

P.S. I will also add comments to the PR where certain parts may be unclear, to better explain the reasoning behind my decisions