### PR TITLE
dbeaver/pro#9755 adds frontend cleanup for js artifacts before each app build

### DIFF
--- a/deploy/build-frontend.sh
+++ b/deploy/build-frontend.sh
@@ -9,6 +9,7 @@ cd ../../cloudbeaver/webapp
 
 yarn install --immutable
 cd ./packages/product-default
+yarn tsc -b --clean
 yarn run bundle
 
 if [[ "$?" -ne 0 ]] ; then

--- a/deploy/build-frontend.sh
+++ b/deploy/build-frontend.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeuo pipefail
+set -Eeuox pipefail
 
 echo "Build static content"
 

--- a/deploy/build-frontend.sh
+++ b/deploy/build-frontend.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeuox pipefail
+set -Eeuo pipefail
 
 echo "Build static content"
 
@@ -8,8 +8,15 @@ mkdir -p ./cloudbeaver/web
 cd ../../cloudbeaver/webapp
 
 yarn install --immutable
-cd ./packages/product-default
-yarn tsc -b --clean
+yarn clear
+
+cd common-react
+yarn clear
+
+cd ../common-typescript
+yarn clear
+
+cd ../packages/product-default
 yarn run bundle
 
 if [[ "$?" -ne 0 ]] ; then


### PR DESCRIPTION
closes https://github.com/dbeaver/pro/issues/9775

We already have `yarn run clean` mechanism which removes all artifacts. so I just reused this mechanism to keep things simple

One thing is that `common-typescript` & `common-react` are not the part of `cloudbeaver/webapp` so it won't recursively clean it too. Thats why I added for it clean commands too