### PR TITLE
Fix source-build prerequisites for Maven 3.9+ and Yarn 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It is free to use and open-source (licensed under [Apache 2](https://github.com/
 ## Documentation
 - [GitHub WIKI](https://github.com/dbeaver/cloudbeaver/wiki)
 - [Official documentation](https://dbeaver.com/docs/cloudbeaver/)
+- [Build from source (prerequisites)](deploy/README.md)
 
 ## Run in Docker
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,72 @@
+# Building CloudBeaver from source
+
+For a full walkthrough see the [Build and deploy](https://github.com/dbeaver/cloudbeaver/wiki/Build-and-deploy) wiki page.
+This file documents prerequisite versions that commonly break source builds (see [#3839](https://github.com/dbeaver/cloudbeaver/issues/3839)).
+
+## Prerequisites
+
+| Tool | Required version |
+|------|------------------|
+| Java | 21 |
+| Apache Maven | **3.9.9+** (Tycho 5; **3.9.16+** recommended) |
+| Node.js | 20.19.1+ (LTS 22.x recommended) |
+| Yarn | **4.x** (see `webapp/package.json` `packageManager`) |
+
+`./build.sh` runs `check-prerequisites.sh` and fails early if these tools are missing or too old.
+
+### Ubuntu / Debian
+
+Do **not** install Maven or Yarn from `apt` for this project. Distro packages are often Maven &lt; 3.9.9 and Yarn 1.x, which fail the CloudBeaver build.
+
+```bash
+# Node.js 22.x
+curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get update
+sudo apt-get install -y openjdk-21-jdk nodejs curl ca-certificates unzip
+
+# Apache Maven 3.9.x (example: 3.9.11)
+curl -fsSL https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz \
+  | sudo tar -xzC /opt
+export PATH="/opt/apache-maven-3.9.11/bin:${PATH}"
+
+# Yarn 4 via Corepack (matches webapp packageManager)
+sudo corepack enable
+corepack prepare yarn@4.14.1 --activate
+
+java -version
+mvn -v
+node -v
+yarn -v
+```
+
+### Windows
+
+- Install [Java 21](https://adoptium.net/).
+- Download [Maven 3.9.9+](https://maven.apache.org/download.cgi) and add its `bin` directory to `PATH`.
+- Install [Node.js LTS 22](https://nodejs.org/), then enable Yarn 4 with Corepack:
+  `corepack enable` and `corepack prepare yarn@4.14.1 --activate`.
+
+## Build
+
+From a clone of this repository (and sibling checkouts of `dbeaver` / `dbeaver-common` as created by the script):
+
+```bash
+cd deploy
+./build.sh
+```
+
+Artifacts are written to `deploy/cloudbeaver`.
+
+### Matching DBeaver platform versions
+
+`build-backend.sh` clones `dbeaver` and `dbeaver-common` from their default branches when those directories are missing.
+To build against a specific release (for example a CloudBeaver tag that must match DBeaver tags), set:
+
+```bash
+export DBEAVER_GIT_REF=25.1.5
+export DBEAVER_COMMON_GIT_REF=25.1.5
+cd deploy
+./build.sh
+```
+
+If you only need to run CloudBeaver, prefer the official [Docker image](https://hub.docker.com/r/dbeaver/cloudbeaver/tags) or the Dockerfiles under `deploy/docker/` instead of a from-source build.

--- a/deploy/build-backend.sh
+++ b/deploy/build-backend.sh
@@ -16,8 +16,24 @@ echo "Pull cloudbeaver platform"
 cd ../..
 
 echo "Pull dbeaver platform"
-[ ! -d dbeaver ] && git clone --depth 1 https://github.com/dbeaver/dbeaver.git
-[ ! -d dbeaver-common ] && git clone --depth 1 https://github.com/dbeaver/dbeaver-common.git
+# Optional: pin platform repos to a release tag/branch (e.g. DBEAVER_GIT_REF=25.1.5).
+# When unset, clones the default branch (devel). See deploy/README.md.
+DBEAVER_GIT_REF="${DBEAVER_GIT_REF:-}"
+DBEAVER_COMMON_GIT_REF="${DBEAVER_COMMON_GIT_REF:-${DBEAVER_GIT_REF}}"
+if [ ! -d dbeaver ]; then
+  if [ -n "${DBEAVER_GIT_REF}" ]; then
+    git clone --depth 1 --branch "${DBEAVER_GIT_REF}" https://github.com/dbeaver/dbeaver.git
+  else
+    git clone --depth 1 https://github.com/dbeaver/dbeaver.git
+  fi
+fi
+if [ ! -d dbeaver-common ]; then
+  if [ -n "${DBEAVER_COMMON_GIT_REF}" ]; then
+    git clone --depth 1 --branch "${DBEAVER_COMMON_GIT_REF}" https://github.com/dbeaver/dbeaver-common.git
+  else
+    git clone --depth 1 https://github.com/dbeaver/dbeaver-common.git
+  fi
+fi
 
 
 cd cloudbeaver/deploy

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-source build-backend.sh 
-source build-frontend.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=check-prerequisites.sh
+source "${SCRIPT_DIR}/check-prerequisites.sh"
+source "${SCRIPT_DIR}/build-backend.sh"
+source "${SCRIPT_DIR}/build-frontend.sh"

--- a/deploy/check-prerequisites.sh
+++ b/deploy/check-prerequisites.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Validate tools required by CloudBeaver builds (Tycho 5 needs Maven 3.9.9+; frontend needs Yarn 4).
+set -Eeuo pipefail
+
+version_ge() {
+  # Return 0 if $1 >= $2 (dot-separated numeric versions).
+  local IFS=.
+  local i
+  local -a v1=($1) v2=($2)
+  for ((i = 0; i < ${#v1[@]} || i < ${#v2[@]}; i++)); do
+    local a=${v1[i]:-0}
+    local b=${v2[i]:-0}
+    if ((10#$a > 10#$b)); then
+      return 0
+    fi
+    if ((10#$a < 10#$b)); then
+      return 1
+    fi
+  done
+  return 0
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  echo "See deploy/README.md for install instructions." >&2
+  exit 1
+}
+
+command -v java >/dev/null 2>&1 || fail "Java is required (Java 21)."
+command -v mvn >/dev/null 2>&1 || fail "Maven is required (3.9.9 or newer)."
+command -v node >/dev/null 2>&1 || fail "Node.js is required (LTS 22.x recommended)."
+command -v yarn >/dev/null 2>&1 || fail "Yarn is required (4.x). Enable Corepack: corepack enable && corepack prepare yarn@4.14.1 --activate"
+
+# Strip ANSI color codes — Maven may colorize when stdout is a TTY.
+MVN_VERSION="$(
+  mvn -v 2>/dev/null \
+    | tr -d '\033' \
+    | sed 's/\[[0-9;]*m//g' \
+    | awk '/Apache Maven/ {print $3; exit}'
+)"
+# Fallback: digits-only match if formatting still interferes
+if [[ ! "${MVN_VERSION}" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+  MVN_VERSION="$(mvn -v 2>/dev/null | grep -oE 'Apache Maven [0-9]+(\.[0-9]+)+' | head -1 | awk '{print $3}')"
+fi
+if [[ -z "${MVN_VERSION}" ]]; then
+  fail "Could not determine Maven version. Install Apache Maven 3.9.9+ (do not rely on older apt packages)."
+fi
+if ! version_ge "${MVN_VERSION}" "3.9.9"; then
+  fail "Maven ${MVN_VERSION} is too old. CloudBeaver uses Tycho 5, which requires Maven 3.9.9+. Ubuntu apt often ships an older Maven — install from https://maven.apache.org/download.cgi"
+fi
+
+NODE_MAJOR="$(node -v 2>/dev/null | sed 's/^v//' | cut -d. -f1)"
+if [[ -z "${NODE_MAJOR}" ]] || ((NODE_MAJOR < 20)); then
+  fail "Node.js $(node -v 2>/dev/null || echo unknown) is too old. Use Node.js 20.19.1+ (LTS 22.x recommended)."
+fi
+
+YARN_VERSION="$(yarn -v 2>/dev/null || true)"
+if [[ -z "${YARN_VERSION}" ]]; then
+  fail "Could not determine Yarn version."
+fi
+YARN_MAJOR="${YARN_VERSION%%.*}"
+if [[ "${YARN_MAJOR}" != "4" ]]; then
+  fail "Yarn ${YARN_VERSION} found, but Yarn 4.x is required (packageManager yarn@4.14.1). apt 'yarn' installs Yarn 1.x — use Corepack instead."
+fi
+
+echo "Prerequisites OK: Maven ${MVN_VERSION}, Node $(node -v), Yarn ${YARN_VERSION}"


### PR DESCRIPTION
## Summary
- Document correct Ubuntu/Debian install steps for building from source: official Maven 3.9.9+ and Yarn 4 via Corepack (apt `maven`/`yarn` break Tycho 5 / frontend builds).
- Add `deploy/check-prerequisites.sh` and run it from `deploy/build.sh` so incompatible tool versions fail early with a clear message.
- Allow optional `DBEAVER_GIT_REF` / `DBEAVER_COMMON_GIT_REF` when cloning platform repos for reproducible release builds.

Fixes #3839

## Test plan
- [x] `bash -n` on updated shell scripts
- [x] `./deploy/check-prerequisites.sh` reports Maven 3.8.7 (apt) as too old with a clear error
- [ ] Confirm wiki Build and deploy Ubuntu section is updated to match (or mirror `deploy/README.md`)