### PR TITLE
dbeaver/pro#10062 syncs cell selection on right click to avoid selection collision

### DIFF
--- a/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/CellRenderer/CellRenderer.tsx
+++ b/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/CellRenderer/CellRenderer.tsx
@@ -195,6 +195,7 @@ export const CellRenderer = observer<Props>(function CellRenderer({ rowIdx, colI
           );
         }
 
+        this.selectionContext.focusCell(this.cellContext.cell);
         this.tableMenuContext.openMenu(this.cellContext.cell, event);
       },
     }),

--- a/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/DataGridSelection/DataGridSelectionContext.ts
+++ b/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/DataGridSelection/DataGridSelectionContext.ts
@@ -15,6 +15,7 @@ export interface IDataGridSelectionContext {
   selectedCells: Map<string, IGridDataKey[]>;
   clearSelection: VoidFunction;
   select: (cell: IDraggingPosition, multiple: boolean, range: boolean, temporary: boolean) => void;
+  focusCell: (key: IGridDataKey) => void;
   selectColumn: (colIdx: number, multiple: boolean) => void;
   selectTable: () => void;
   isSelected: (rowIdx: number, colIdx: number) => boolean;

--- a/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/DataGridSelection/useGridSelectionContext.tsx
+++ b/webapp/packages/plugin-data-spreadsheet-new/src/DataGrid/DataGridSelection/useGridSelectionContext.tsx
@@ -181,6 +181,10 @@ export function useGridSelectionContext(
     props.selectionAction.set({}, true);
   }
 
+  function focusCell(key: IGridDataKey) {
+    props.selectionAction.focus(key);
+  }
+
   function isSelected(rowIdx: number, colIdx: number) {
     const column = props.tableData.getColumn(colIdx)?.key ?? undefined;
 
@@ -286,6 +290,7 @@ export function useGridSelectionContext(
         return props.selectionAction.selectedElements;
       },
       select,
+      focusCell,
       selectColumn,
       selectTable,
       getFocusedElementPosition,


### PR DESCRIPTION
closes https://github.com/dbeaver/pro/issues/10062

syncs focus to the right-clicked cell in CellRenderer.openContextMenu before opening the context menu, via a new focusCell method on the selection context. This guarantees the app's focus always matches the clicked cell, regardless of whether react-data-grid emitted a position-change event