### PR TITLE
dbeaver/pro#8752 fix: change loaders check

### DIFF
--- a/webapp/packages/core-ui/src/ContextMenu/SubMenuElement.tsx
+++ b/webapp/packages/core-ui/src/ContextMenu/SubMenuElement.tsx
@@ -76,7 +76,7 @@ export const SubMenuElement = observer<ISubMenuElementProps>(function SubMenuEle
     }
 
     const hasVisibleItems = subMenuData.items.some(item => !item.hidden);
-    const canLazyLoadItems = subMenuData.loaders.length > 0;
+    const canLazyLoadItems = subMenuData.loaders.some(loader => !loader.isLoaded());
 
     return !hasVisibleItems && !canLazyLoadItems;
   });


### PR DESCRIPTION
A loader that has already finished can no longer add items, so it must not keep a submenu alive