### PR TITLE
dbeaver/pro#9948 fix: show unsaved changes dialog on tab change

### DIFF
--- a/webapp/packages/core-ui/src/Tabs/Tab/useTab.ts
+++ b/webapp/packages/core-ui/src/Tabs/Tab/useTab.ts
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,6 @@ export function useTab(
           return;
         }
         refObject.onClick?.(this.tabId);
-        this.state.open(this.tabId);
       },
       handleClose(e: React.MouseEvent<HTMLDivElement>) {
         EventContext.set(e, EventStopPropagationFlag); // TODO: probably should use special flag

--- a/webapp/packages/plugin-user-profile-settings/src/UserProfileSettingsPluginBootstrap.ts
+++ b/webapp/packages/plugin-user-profile-settings/src/UserProfileSettingsPluginBootstrap.ts
@@ -33,7 +33,7 @@ export class UserProfileSettingsPluginBootstrap extends Bootstrap {
 
   override register(): void {
     this.userProfileOptionsPanelService.onClose.addHandler(this.confirmDiscardChanges.bind(this));
-    this.userProfileOptionsPanelService.onBeforeTabChange.addHandler(this.confirmDiscardChanges.bind(this));
+    this.userProfileTabsService.onBeforeTabChange.addHandler(this.confirmDiscardChanges.bind(this));
 
     this.userProfileTabsService.tabContainer.add({
       key: SETTINGS_TAB_ID,
@@ -62,7 +62,7 @@ export class UserProfileSettingsPluginBootstrap extends Bootstrap {
         };
       },
       handler: async () => {
-        await this.userProfileOptionsPanelService.open(SETTINGS_TAB_ID);
+        await this.userProfileTabsService.open(SETTINGS_TAB_ID);
       },
     });
   }

--- a/webapp/packages/plugin-user-profile-settings/src/UserProfileSettingsPluginBootstrap.ts
+++ b/webapp/packages/plugin-user-profile-settings/src/UserProfileSettingsPluginBootstrap.ts
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -8,7 +8,7 @@
 import { ConfirmationDialog, importLazyComponent } from '@cloudbeaver/core-blocks';
 import { Bootstrap, injectable } from '@cloudbeaver/core-di';
 import { CommonDialogService, DialogueStateResult } from '@cloudbeaver/core-dialogs';
-import { ExecutorInterrupter } from '@cloudbeaver/core-executor';
+import { ExecutorInterrupter, type IExecutionContextProvider } from '@cloudbeaver/core-executor';
 import { UserSettingsService } from '@cloudbeaver/core-settings-user';
 import { ACTION_SETTINGS, ActionService, MenuService } from '@cloudbeaver/core-view';
 import { TOP_NAV_BAR_SETTINGS_MENU } from '@cloudbeaver/plugin-settings-menu';
@@ -32,25 +32,8 @@ export class UserProfileSettingsPluginBootstrap extends Bootstrap {
   }
 
   override register(): void {
-    this.userProfileOptionsPanelService.onClose.addHandler(async (data, context) => {
-      if (!this.userSettingsService.isEdited()) {
-        return;
-      }
-
-      const { status } = await this.commonDialogService.open(ConfirmationDialog, {
-        title: 'ui_discard_changes',
-        message: 'ui_discard_changes_message',
-        confirmActionText: 'ui_discard',
-        cancelActionText: 'ui_keep_editing',
-      });
-
-      if (status === DialogueStateResult.Rejected) {
-        ExecutorInterrupter.interrupt(context);
-        return;
-      }
-
-      this.userSettingsService.resetChanges();
-    });
+    this.userProfileOptionsPanelService.onClose.addHandler(this.confirmDiscardChanges.bind(this));
+    this.userProfileOptionsPanelService.onBeforeTabChange.addHandler(this.confirmDiscardChanges.bind(this));
 
     this.userProfileTabsService.tabContainer.add({
       key: SETTINGS_TAB_ID,
@@ -82,5 +65,25 @@ export class UserProfileSettingsPluginBootstrap extends Bootstrap {
         await this.userProfileOptionsPanelService.open(SETTINGS_TAB_ID);
       },
     });
+  }
+
+  private async confirmDiscardChanges(_: unknown, contexts: IExecutionContextProvider<any>): Promise<void> {
+    if (!this.userSettingsService.isEdited()) {
+      return;
+    }
+
+    const { status } = await this.commonDialogService.open(ConfirmationDialog, {
+      title: 'ui_discard_changes',
+      message: 'ui_discard_changes_message',
+      confirmActionText: 'ui_discard',
+      cancelActionText: 'ui_keep_editing',
+    });
+
+    if (status === DialogueStateResult.Rejected) {
+      ExecutorInterrupter.interrupt(contexts);
+      return;
+    }
+
+    this.userSettingsService.resetChanges();
   }
 }

--- a/webapp/packages/plugin-user-profile/src/UserInfo.tsx
+++ b/webapp/packages/plugin-user-profile/src/UserInfo.tsx
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@ import { useService } from '@cloudbeaver/core-di';
 import type { UserInfo as IUserInfo } from '@cloudbeaver/core-sdk';
 
 import styles from './UserInfo.module.css';
-import { UserProfileOptionsPanelService } from './UserProfileOptionsPanelService.js';
+import { UserProfileTabsService } from './UserProfileTabsService.js';
 import { Command } from '@dbeaver/ui-kit';
 
 interface Props {
@@ -21,7 +21,7 @@ interface Props {
 
 export const UserInfo = observer<Props>(function UserInfo({ info }) {
   const translate = useTranslate();
-  const userProfileOptionsPanelService = useService(UserProfileOptionsPanelService);
+  const userProfileTabsService = useService(UserProfileTabsService);
   const style = useS(styles);
 
   return (
@@ -29,7 +29,7 @@ export const UserInfo = observer<Props>(function UserInfo({ info }) {
       render={<div />}
       className={s(style, { user: true })}
       title={translate('plugin_user_profile_menu')}
-      onClick={() => userProfileOptionsPanelService.open()}
+      onClick={() => userProfileTabsService.open()}
     >
       <IconOrImage className={s(style, { iconOrImage: true })} icon="/icons/plugin_user_profile_m.svg" />
       <div className={s(style, { userName: true })}>{info.displayName || info.userId}</div>

--- a/webapp/packages/plugin-user-profile/src/UserProfileForm/UserAuthenticationPart/ChangePassword.tsx
+++ b/webapp/packages/plugin-user-profile/src/UserProfileForm/UserAuthenticationPart/ChangePassword.tsx
@@ -5,13 +5,11 @@
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
  */
-import { observable } from 'mobx';
 import { observer } from 'mobx-react-lite';
 
 import { UserInfoResource } from '@cloudbeaver/core-authentication';
 import {
   ColoredContainer,
-  ConfirmationDialog,
   Container,
   Form,
   Group,
@@ -19,40 +17,23 @@ import {
   InputField,
   ToolsAction,
   ToolsPanel,
-  useExecutor,
   useForm,
   useFormCustomInputValidation,
-  useObservableRef,
   usePasswordValidation,
   useTranslate,
 } from '@cloudbeaver/core-blocks';
 import { useService } from '@cloudbeaver/core-di';
-import { CommonDialogService, DialogueStateResult } from '@cloudbeaver/core-dialogs';
 import { NotificationService } from '@cloudbeaver/core-events';
-import { ExecutorInterrupter } from '@cloudbeaver/core-executor';
 import { isValuesEqual } from '@cloudbeaver/core-utils';
 
-import { userProfileContext } from '../../userProfileContext.js';
-import { UserProfileOptionsPanelService } from '../../UserProfileOptionsPanelService.js';
+import { UserProfileFormAuthenticationService } from './UserProfileFormAuthenticationService.js';
 
 export const ChangePassword = observer(function ChangePassword() {
   const translate = useTranslate();
-  const state = useObservableRef(
-    {
-      oldPassword: '',
-      password: '',
-      repeatedPassword: '',
-    },
-    {
-      oldPassword: observable.ref,
-      password: observable.ref,
-      repeatedPassword: observable.ref,
-    },
-  );
   const notificationService = useService(NotificationService);
-  const userProfileOptionsPanelService = useService(UserProfileOptionsPanelService);
+  const userProfileFormAuthenticationPartStateService = useService(UserProfileFormAuthenticationService);
   const userInfoResource = useService(UserInfoResource);
-  const commonDialogService = useService(CommonDialogService);
+  const state = userProfileFormAuthenticationPartStateService.state;
   const disabled = userInfoResource.isLoading();
 
   const form = useForm({
@@ -77,33 +58,9 @@ export const ChangePassword = observer(function ChangePassword() {
   }, form);
 
   function resetForm() {
-    state.oldPassword = '';
-    state.password = '';
-    state.repeatedPassword = '';
+    userProfileFormAuthenticationPartStateService.reset();
     form.ref?.reset();
   }
-
-  useExecutor({
-    executor: userProfileOptionsPanelService.onClose,
-    handlers: [
-      async function closeHandler(_, contexts) {
-        const context = contexts.getContext(userProfileContext);
-
-        if ((state.oldPassword || state.password || state.repeatedPassword) && !context.force) {
-          const { status } = await commonDialogService.open(ConfirmationDialog, {
-            title: 'ui_discard_changes',
-            message: 'ui_discard_changes_message',
-            confirmActionText: 'ui_discard',
-            cancelActionText: 'ui_keep_editing',
-          });
-
-          if (status === DialogueStateResult.Rejected) {
-            ExecutorInterrupter.interrupt(contexts);
-          }
-        }
-      },
-    ],
-  });
 
   return (
     <ColoredContainer wrap overflow gap>

--- a/webapp/packages/plugin-user-profile/src/UserProfileForm/UserAuthenticationPart/UserProfileFormAuthenticationPartBootstrap.ts
+++ b/webapp/packages/plugin-user-profile/src/UserProfileForm/UserAuthenticationPart/UserProfileFormAuthenticationPartBootstrap.ts
@@ -1,28 +1,45 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2024 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
  */
 import { UserInfoResource } from '@cloudbeaver/core-authentication';
-import { importLazyComponent } from '@cloudbeaver/core-blocks';
+import { ConfirmationDialog, importLazyComponent } from '@cloudbeaver/core-blocks';
 import { Bootstrap, injectable } from '@cloudbeaver/core-di';
+import { CommonDialogService, DialogueStateResult } from '@cloudbeaver/core-dialogs';
+import { ExecutorInterrupter, type IExecutionContextProvider } from '@cloudbeaver/core-executor';
 
+import { userProfileContext } from '../../userProfileContext.js';
 import { UserProfileTabsService } from '../../UserProfileTabsService.js';
+import { UserProfileOptionsPanelService } from '../../UserProfileOptionsPanelService.js';
+import { UserProfileFormAuthenticationService } from './UserProfileFormAuthenticationService.js';
 
 const ChangePassword = importLazyComponent(() => import('./ChangePassword.js').then(m => m.ChangePassword));
 
-@injectable(() => [UserProfileTabsService, UserInfoResource])
+@injectable(() => [
+  UserProfileTabsService,
+  UserInfoResource,
+  UserProfileOptionsPanelService,
+  UserProfileFormAuthenticationService,
+  CommonDialogService,
+])
 export class UserProfileFormAuthenticationPartBootstrap extends Bootstrap {
   constructor(
     private readonly userProfileTabsService: UserProfileTabsService,
     private readonly userInfoResource: UserInfoResource,
+    private readonly userProfileOptionsPanelService: UserProfileOptionsPanelService,
+    private readonly userProfileFormAuthenticationPartStateService: UserProfileFormAuthenticationService,
+    private readonly commonDialogService: CommonDialogService,
   ) {
     super();
   }
 
   override register(): void {
+    this.userProfileOptionsPanelService.onClose.addHandler(this.closeHandler.bind(this));
+    this.userProfileTabsService.onBeforeTabChange.addHandler(this.tabChangeHandler.bind(this));
+
     this.userProfileTabsService.tabContainer.add({
       key: 'authentication',
       name: 'ui_authentication',
@@ -30,5 +47,40 @@ export class UserProfileFormAuthenticationPartBootstrap extends Bootstrap {
       isHidden: () => this.userInfoResource.isAnonymous(),
       panel: () => ChangePassword,
     });
+  }
+
+  private async closeHandler(_: unknown, contexts: IExecutionContextProvider<any>): Promise<void> {
+    const context = contexts.getContext(userProfileContext);
+
+    if (context.force) {
+      this.userProfileFormAuthenticationPartStateService.reset();
+      return;
+    }
+
+    await this.confirmDiscardChanges(contexts);
+  }
+
+  private async tabChangeHandler(_: string, contexts: IExecutionContextProvider<string>): Promise<void> {
+    await this.confirmDiscardChanges(contexts);
+  }
+
+  private async confirmDiscardChanges(contexts: IExecutionContextProvider<any>): Promise<void> {
+    if (!this.userProfileFormAuthenticationPartStateService.isEdited()) {
+      return;
+    }
+
+    const { status } = await this.commonDialogService.open(ConfirmationDialog, {
+      title: 'ui_discard_changes',
+      message: 'ui_discard_changes_message',
+      confirmActionText: 'ui_discard',
+      cancelActionText: 'ui_keep_editing',
+    });
+
+    if (status === DialogueStateResult.Rejected) {
+      ExecutorInterrupter.interrupt(contexts);
+      return;
+    }
+
+    this.userProfileFormAuthenticationPartStateService.reset();
   }
 }

--- a/webapp/packages/plugin-user-profile/src/UserProfileForm/UserAuthenticationPart/UserProfileFormAuthenticationService.ts
+++ b/webapp/packages/plugin-user-profile/src/UserProfileForm/UserAuthenticationPart/UserProfileFormAuthenticationService.ts
@@ -1,0 +1,40 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+import { action, makeObservable, observable } from 'mobx';
+
+import { injectable } from '@cloudbeaver/core-di';
+
+import type { IUserProfileFormAuthenticationState } from './IUserProfileFormAuthenticationState.js';
+
+@injectable()
+export class UserProfileFormAuthenticationService {
+  readonly state: IUserProfileFormAuthenticationState;
+
+  constructor() {
+    this.state = {
+      oldPassword: '',
+      password: '',
+      repeatedPassword: '',
+    };
+
+    makeObservable(this, {
+      state: observable,
+      reset: action,
+    });
+  }
+
+  isEdited(): boolean {
+    return !!(this.state.oldPassword || this.state.password || this.state.repeatedPassword);
+  }
+
+  reset(): void {
+    this.state.oldPassword = '';
+    this.state.password = '';
+    this.state.repeatedPassword = '';
+  }
+}

--- a/webapp/packages/plugin-user-profile/src/UserProfileOptionsPanel.tsx
+++ b/webapp/packages/plugin-user-profile/src/UserProfileOptionsPanel.tsx
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,13 @@ export const UserProfileOptionsPanel = observer(function UserProfileOptionsPanel
 
   return (
     <ColoredContainer className={s(styles, { userProfileOptionsPanel: true })} overflow parent compact vertical noWrap maximum>
-      <TabsState container={userProfileTabsService.tabContainer} selectedId={userProfileOptionsPanelService.itemId ?? undefined} lazy>
+      <TabsState
+        container={userProfileTabsService.tabContainer}
+        currentTabId={userProfileOptionsPanelService.itemId ?? undefined}
+        autoSelect={false}
+        lazy
+        onChange={tab => userProfileOptionsPanelService.open(tab.tabId)}
+      >
         <Group overflow box keepSize noWrap>
           <SContext registry={tabsStyleRegistry}>
             <TabList underline />

--- a/webapp/packages/plugin-user-profile/src/UserProfileOptionsPanel.tsx
+++ b/webapp/packages/plugin-user-profile/src/UserProfileOptionsPanel.tsx
@@ -15,23 +15,21 @@ import { TabList, TabPanelList, TabsState, TabStyles } from '@cloudbeaver/core-u
 import style from './UserProfileOptionsPanel.module.css';
 import UserProfileTabStyles from './UserProfileTab.module.css';
 import { UserProfileTabsService } from './UserProfileTabsService.js';
-import { UserProfileOptionsPanelService } from './UserProfileOptionsPanelService.js';
 
 export const tabsStyleRegistry: StyleRegistry = [[TabStyles, { mode: 'append', styles: [UserProfileTabStyles] }]];
 
 export const UserProfileOptionsPanel = observer(function UserProfileOptionsPanel() {
   const styles = useS(style);
   const userProfileTabsService = useService(UserProfileTabsService);
-  const userProfileOptionsPanelService = useService(UserProfileOptionsPanelService);
 
   return (
     <ColoredContainer className={s(styles, { userProfileOptionsPanel: true })} overflow parent compact vertical noWrap maximum>
       <TabsState
         container={userProfileTabsService.tabContainer}
-        currentTabId={userProfileOptionsPanelService.itemId ?? undefined}
+        currentTabId={userProfileTabsService.selectedTabId}
         autoSelect={false}
         lazy
-        onChange={tab => userProfileOptionsPanelService.open(tab.tabId)}
+        onChange={tab => userProfileTabsService.open(tab.tabId)}
       >
         <Group overflow box keepSize noWrap>
           <SContext registry={tabsStyleRegistry}>

--- a/webapp/packages/plugin-user-profile/src/UserProfileOptionsPanelService.ts
+++ b/webapp/packages/plugin-user-profile/src/UserProfileOptionsPanelService.ts
@@ -8,42 +8,30 @@
 import { UserInfoResource } from '@cloudbeaver/core-authentication';
 import { importLazyComponent } from '@cloudbeaver/core-blocks';
 import { injectable } from '@cloudbeaver/core-di';
-import { ExecutionContext, Executor, ExecutorInterrupter, type IExecutor, type ISyncExecutor, SyncExecutor } from '@cloudbeaver/core-executor';
+import { ExecutionContext, type ISyncExecutor, SyncExecutor } from '@cloudbeaver/core-executor';
 import { BaseOptionsPanelService, OptionsPanelService } from '@cloudbeaver/core-ui';
 
 import { userProfileContext } from './userProfileContext.js';
-import { UserProfileTabsService } from './UserProfileTabsService.js';
 
 const UserProfileOptionsPanel = importLazyComponent(() => import('./UserProfileOptionsPanel.js').then(m => m.UserProfileOptionsPanel));
 const panelGetter = () => UserProfileOptionsPanel;
 
-@injectable(() => [OptionsPanelService, UserInfoResource, UserProfileTabsService])
-export class UserProfileOptionsPanelService extends BaseOptionsPanelService<string | undefined> {
+@injectable(() => [OptionsPanelService, UserInfoResource])
+export class UserProfileOptionsPanelService extends BaseOptionsPanelService<void> {
   readonly onOpen: ISyncExecutor;
-  readonly onBeforeTabChange: IExecutor<string>;
 
   constructor(
     optionsPanelService: OptionsPanelService,
     private readonly userInfoResource: UserInfoResource,
-    private readonly userProfileTabsService: UserProfileTabsService,
   ) {
     super(optionsPanelService, panelGetter);
 
     this.onOpen = new SyncExecutor();
-    this.onBeforeTabChange = new Executor();
     this.userInfoResource.onDataUpdate.addHandler(this.userUpdateHandler.bind(this));
   }
 
-  override async open(tabId?: string): Promise<boolean> {
-    if (this.isOpen()) {
-      if (tabId !== undefined) {
-        await this.selectTab(tabId);
-      }
-
-      return true;
-    }
-
-    const state = await super.open(tabId ?? this.userProfileTabsService.tabContainer.getIdList()[0]);
+  override async open(): Promise<boolean> {
+    const state = await super.open();
 
     if (state) {
       this.onOpen.execute();
@@ -65,20 +53,6 @@ export class UserProfileOptionsPanelService extends BaseOptionsPanelService<stri
     }
 
     await this.optionsPanelService.close(context);
-  }
-
-  private async selectTab(tabId: string): Promise<void> {
-    if (this.itemId === tabId) {
-      return;
-    }
-
-    const contexts = await this.onBeforeTabChange.execute(tabId);
-
-    if (ExecutorInterrupter.isInterrupted(contexts)) {
-      return;
-    }
-
-    this.itemId = tabId;
   }
 
   private userUpdateHandler() {

--- a/webapp/packages/plugin-user-profile/src/UserProfileOptionsPanelService.ts
+++ b/webapp/packages/plugin-user-profile/src/UserProfileOptionsPanelService.ts
@@ -1,15 +1,14 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
  */
-
 import { UserInfoResource } from '@cloudbeaver/core-authentication';
 import { importLazyComponent } from '@cloudbeaver/core-blocks';
 import { injectable } from '@cloudbeaver/core-di';
-import { ExecutionContext, type ISyncExecutor, SyncExecutor } from '@cloudbeaver/core-executor';
+import { ExecutionContext, Executor, ExecutorInterrupter, type IExecutor, type ISyncExecutor, SyncExecutor } from '@cloudbeaver/core-executor';
 import { BaseOptionsPanelService, OptionsPanelService } from '@cloudbeaver/core-ui';
 
 import { userProfileContext } from './userProfileContext.js';
@@ -21,19 +20,30 @@ const panelGetter = () => UserProfileOptionsPanel;
 @injectable(() => [OptionsPanelService, UserInfoResource, UserProfileTabsService])
 export class UserProfileOptionsPanelService extends BaseOptionsPanelService<string | undefined> {
   readonly onOpen: ISyncExecutor;
+  readonly onBeforeTabChange: IExecutor<string>;
 
   constructor(
     optionsPanelService: OptionsPanelService,
     private readonly userInfoResource: UserInfoResource,
+    private readonly userProfileTabsService: UserProfileTabsService,
   ) {
     super(optionsPanelService, panelGetter);
 
     this.onOpen = new SyncExecutor();
+    this.onBeforeTabChange = new Executor();
     this.userInfoResource.onDataUpdate.addHandler(this.userUpdateHandler.bind(this));
   }
 
   override async open(tabId?: string): Promise<boolean> {
-    const state = await super.open(tabId);
+    if (this.isOpen()) {
+      if (tabId !== undefined) {
+        await this.selectTab(tabId);
+      }
+
+      return true;
+    }
+
+    const state = await super.open(tabId ?? this.userProfileTabsService.tabContainer.getIdList()[0]);
 
     if (state) {
       this.onOpen.execute();
@@ -55,6 +65,20 @@ export class UserProfileOptionsPanelService extends BaseOptionsPanelService<stri
     }
 
     await this.optionsPanelService.close(context);
+  }
+
+  private async selectTab(tabId: string): Promise<void> {
+    if (this.itemId === tabId) {
+      return;
+    }
+
+    const contexts = await this.onBeforeTabChange.execute(tabId);
+
+    if (ExecutorInterrupter.isInterrupted(contexts)) {
+      return;
+    }
+
+    this.itemId = tabId;
   }
 
   private userUpdateHandler() {

--- a/webapp/packages/plugin-user-profile/src/UserProfileTabsService.ts
+++ b/webapp/packages/plugin-user-profile/src/UserProfileTabsService.ts
@@ -1,18 +1,62 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2024 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
  */
+import { action, makeObservable, observable } from 'mobx';
+
 import { injectable } from '@cloudbeaver/core-di';
+import { Executor, ExecutorInterrupter, type IExecutor } from '@cloudbeaver/core-executor';
 import { TabsContainer } from '@cloudbeaver/core-ui';
 
-@injectable()
-export class UserProfileTabsService {
-  readonly tabContainer: TabsContainer;
+import { UserProfileOptionsPanelService } from './UserProfileOptionsPanelService.js';
 
-  constructor() {
+@injectable(() => [UserProfileOptionsPanelService])
+export class UserProfileTabsService {
+  selectedTabId: string | null;
+  readonly tabContainer: TabsContainer;
+  readonly onBeforeTabChange: IExecutor<string>;
+
+  constructor(private readonly userProfileOptionsPanelService: UserProfileOptionsPanelService) {
+    this.selectedTabId = null;
     this.tabContainer = new TabsContainer('User Profile');
+    this.onBeforeTabChange = new Executor();
+
+    this.userProfileOptionsPanelService.onClose.addHandler(data => {
+      if (data === 'after') {
+        this.selectedTabId = null;
+      }
+    });
+
+    makeObservable(this, {
+      selectedTabId: observable.ref,
+      open: action,
+    });
+  }
+
+  async open(tabId?: string): Promise<boolean> {
+    if (!this.userProfileOptionsPanelService.isOpen()) {
+      this.selectedTabId = tabId ?? this.tabContainer.getIdList()[0] ?? null;
+
+      const state = await this.userProfileOptionsPanelService.open();
+
+      if (!state) {
+        this.selectedTabId = null;
+      }
+
+      return state;
+    }
+
+    if (tabId !== undefined && tabId !== this.selectedTabId) {
+      const contexts = await this.onBeforeTabChange.execute(tabId);
+
+      if (!ExecutorInterrupter.isInterrupted(contexts)) {
+        this.selectedTabId = tabId;
+      }
+    }
+
+    return true;
   }
 }

--- a/webapp/packages/plugin-user-profile/src/module.ts
+++ b/webapp/packages/plugin-user-profile/src/module.ts
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@ import { UserProfileTabsService } from './UserProfileTabsService.js';
 import { UserProfileOptionsPanelService } from './UserProfileOptionsPanelService.js';
 import { UserProfileFormInfoPartBootstrap } from './UserProfileForm/UserInfoPart/UserProfileFormInfoPartBootstrap.js';
 import { UserProfileFormAuthenticationPartBootstrap } from './UserProfileForm/UserAuthenticationPart/UserProfileFormAuthenticationPartBootstrap.js';
+import { UserProfileFormAuthenticationService } from './UserProfileForm/UserAuthenticationPart/UserProfileFormAuthenticationService.js';
 import { PluginBootstrap } from './PluginBootstrap.js';
 import { LocaleService } from './LocaleService.js';
 
@@ -26,6 +27,7 @@ export default ModuleRegistry.add({
       .addSingleton(UserProfileTabsService)
       .addSingleton(UserProfileOptionsPanelService)
       .addSingleton(UserProfileFormInfoPartBootstrap)
-      .addSingleton(UserProfileFormAuthenticationPartBootstrap);
+      .addSingleton(UserProfileFormAuthenticationPartBootstrap)
+      .addSingleton(UserProfileFormAuthenticationService);
   },
 });


### PR DESCRIPTION
A tab click triggered `openExecutor` twice: once from `useTab.handleOpen` calling `state.open()`. And again from Ariakit's own `onClick` calling `store.setSelectedId()` → `select()`. Since `TabsState` already wires the Ariakit store to `openExecutor` in both controlled and uncontrolled modes, the explicit `state.open()` call is redundant.

https://github.com/user-attachments/assets/6f00dc75-c772-4d9f-b528-6af92758f278


https://github.com/user-attachments/assets/ea5d58f9-dc60-4e2a-a148-8522ac358f95


https://github.com/user-attachments/assets/2775a742-6aa3-4eb2-9b35-2f41e65361d3
