### PR TITLE
dbeaver/pro#10229 fixes references panel select popover position

### DIFF
--- a/webapp/common-react/@dbeaver/ui-kit/src/Select/SelectField.tsx
+++ b/webapp/common-react/@dbeaver/ui-kit/src/Select/SelectField.tsx
@@ -98,6 +98,8 @@ export interface ISelectFieldProps<T, ItemType = ISelectItem<T>> {
 
   portal?: boolean;
 
+  overflowPadding?: number;
+
   autoFocusItemsOnShow?: boolean;
 
   'aria-labelledby'?: string;
@@ -144,6 +146,7 @@ export function SelectField<T, ItemType extends {} = ISelectItem<T>>({
   required,
   className,
   portal = false,
+  overflowPadding,
   selectedRender,
   arrowIcon,
   store,
@@ -229,7 +232,7 @@ export function SelectField<T, ItemType extends {} = ISelectItem<T>>({
         </Select>
         {description && <span className="dbv-kit-select__description">{description}</span>}
 
-        <SelectPopover autoFocusOnShow={autoFocusItemsOnShow} portal={portal} gutter={4} unmountOnHide>
+        <SelectPopover autoFocusOnShow={autoFocusItemsOnShow} portal={portal} overflowPadding={overflowPadding} gutter={4} unmountOnHide>
           {headerItems && headerItems.length > 0 && (
             <SelectGroup className="dbv-kit-select__popover-header">{headerItems.map(renderSelectItem)}</SelectGroup>
           )}

--- a/webapp/packages/core-blocks/src/FormControls/Select.tsx
+++ b/webapp/packages/core-blocks/src/FormControls/Select.tsx
@@ -41,6 +41,7 @@ export type SelectBaseProps<TKey, TValue> = Omit<
     inline?: boolean;
     children?: string;
     portal?: boolean;
+    overflowPadding?: number;
     headerItems?: TValue[];
     footerItems?: TValue[];
   };
@@ -71,6 +72,7 @@ export const Select: ISelectType = observer(function Select({
   state,
   items,
   portal = false,
+  overflowPadding,
   loading,
   children,
   title,
@@ -158,7 +160,9 @@ export const Select: ISelectType = observer(function Select({
     return (
       <div className="select__item">
         {renderIcon(item)}
-        <span className="tw:truncate tw:min-w-0" title={titleSelector?.(item) ?? valueSelector(item)}>{valueSelector(item)}</span>
+        <span className="tw:truncate tw:min-w-0" title={titleSelector?.(item) ?? valueSelector(item)}>
+          {valueSelector(item)}
+        </span>
       </div>
     );
   }
@@ -189,6 +193,7 @@ export const Select: ISelectType = observer(function Select({
       <SelectField
         {...rest}
         portal={portal}
+        overflowPadding={overflowPadding}
         items={items}
         value={value}
         id={inputId}

--- a/webapp/packages/plugin-data-viewer-references/src/DataViewerReferencesPresentation.tsx
+++ b/webapp/packages/plugin-data-viewer-references/src/DataViewerReferencesPresentation.tsx
@@ -99,6 +99,7 @@ export const DataViewerReferencesPresentation: DataPresentationComponent = obser
                 icon="/icons/plugin_data_viewer_references_panel_arrow_sm.svg"
               />
             )}
+            portal
           />
           {currentAssociation.targetNodePath && (
             <Button size="small" variant="secondary" onClick={openAssociation}>

--- a/webapp/packages/plugin-data-viewer-references/src/DataViewerReferencesPresentation.tsx
+++ b/webapp/packages/plugin-data-viewer-references/src/DataViewerReferencesPresentation.tsx
@@ -93,13 +93,13 @@ export const DataViewerReferencesPresentation: DataPresentationComponent = obser
             keySelector={association => association.id}
             titleSelector={getValueSelector}
             valueSelector={getValueSelector}
+            overflowPadding={0}
             iconSelector={association => (
               <IconOrImage
                 className={clsx(association.reference && 'tw:rotate-180')}
                 icon="/icons/plugin_data_viewer_references_panel_arrow_sm.svg"
               />
             )}
-            portal
           />
           {currentAssociation.targetNodePath && (
             <Button size="small" variant="secondary" onClick={openAssociation}>


### PR DESCRIPTION
closes https://github.com/dbeaver/pro/issues/10229

because of the one of the parents overflow AriaKit calculates popover position depending on the context where it was rendered. so in our case it decided to add 8px so popover is fully visible and not overflowed by the container

in portal mode this works fine since it is in portal context and it don't care about container context layout. but portal prop here is not a good fit due to modal dialogs like session expire, for example is not covering this select (layout looks broken with select's popover)

so I decided to fix overflowPadding prop since it looks fine and pretty controllable in the code 