### PR TITLE
dbeaver/pro#5650 hotfix -> release_26_1_5: Add fields for SSL: databend driver is enable in cb-ce

### DIFF
--- a/server/bundles/io.cloudbeaver.resources.drivers.base/plugin.xml
+++ b/server/bundles/io.cloudbeaver.resources.drivers.base/plugin.xml
@@ -66,7 +66,7 @@
         <driver id="generic:trino_jdbc"/>
         <driver id="duckdb:duckdb_jdbc"/>
         <driver id="generic:kyuubi_hive"/>
-        <driver id="databend:databend"/>
+        <driver id="databend:databend_jdbc"/>
     </extension>
 
 


### PR DESCRIPTION
…nd driver is enable in cb-ce