### PR TITLE
dbeaver/pro#10315 Persist deleted AI profiles

### DIFF
--- a/server/bundles/io.cloudbeaver.service.ai/src/io/cloudbeaver/service/ai/gql/WebServiceAI.java
+++ b/server/bundles/io.cloudbeaver.service.ai/src/io/cloudbeaver/service/ai/gql/WebServiceAI.java
@@ -538,6 +538,8 @@ public class WebServiceAI implements DBWServiceAI {
             AISettings settings = AISettingsManager.getInstance().getSettings();
             AIConfigurationProfile profile = settings.getConfiguration(profileId);
             settings.removeConfiguration(profile);
+            AISettingsManager.getInstance().saveSettings();
+            addAISettingsChangedEvent(webSession);
         } catch (DBException e) {
             throw new DBWebException("Error deleting AI configuration " + profileId, e);
         }


### PR DESCRIPTION
Closes dbeaver/pro#10315

## Summary
- persist AI settings after deleting a profile
- notify connected clients about the workspace configuration change

## Testing
- `mvn clean verify -f server/product/aggregate/pom.xml -T 1C`

This PR was generated with AI assistance.