### PR TITLE
dbeaver/pro#8982 Skip ineffective connection notifications

### DIFF
--- a/server/bundles/io.cloudbeaver.model/src/io/cloudbeaver/WebSessionProjectImpl.java
+++ b/server/bundles/io.cloudbeaver.model/src/io/cloudbeaver/WebSessionProjectImpl.java
@@ -237,6 +237,18 @@ public class WebSessionProjectImpl extends WebProjectImpl implements DBPAdaptabl
     public synchronized boolean updateProjectDataSources(@NotNull WSDataSourceEvent event) {
         var sendDataSourceUpdatedEvent = false;
         DBPDataSourceRegistry registry = getDataSourceRegistry();
+        Map<String, DataSourceDescriptor> dataSourceSnapshots = new HashMap<>();
+        if (WSDataSourceEvent.UPDATED.equals(event.getId())) {
+            for (String dsId : event.getDataSourceIds()) {
+                DBPDataSourceContainer dataSource = registry.getDataSource(dsId);
+                if (dataSource instanceof DataSourceDescriptor descriptor) {
+                    DBPDataSourceContainer snapshot = registry.createDataSource(descriptor);
+                    if (snapshot instanceof DataSourceDescriptor snapshotDescriptor) {
+                        dataSourceSnapshots.put(dsId, snapshotDescriptor);
+                    }
+                }
+            }
+        }
         if (WSDataSourceEvent.CREATED.equals(event.getId()) || WSDataSourceEvent.UPDATED.equals(event.getId())) {
             registry.refreshConfig(event.getDataSourceIds());
         }
@@ -251,6 +263,10 @@ public class WebSessionProjectImpl extends WebProjectImpl implements DBPAdaptabl
                     sendDataSourceUpdatedEvent = true;
                 }
                 case WSDataSourceEvent.UPDATED ->  {
+                    DataSourceDescriptor snapshot = dataSourceSnapshots.get(dsId);
+                    if (snapshot != null && !event.getProperty().hasEffectiveChanges(snapshot, ds)) {
+                        continue;
+                    }
                     if (event.getProperty() == WSDataSourceProperty.CONFIGURATION) {
                         WebDataSourceUtils.disconnectDataSource(webSession, ds, true);
                     }

--- a/server/test/io.cloudbeaver.test.platform/src/io/cloudbeaver/model/session/BaseProjectSettingsTest.java
+++ b/server/test/io.cloudbeaver.test.platform/src/io/cloudbeaver/model/session/BaseProjectSettingsTest.java
@@ -1,0 +1,89 @@
+/*
+ * CloudBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudbeaver.model.session;
+
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.model.DBPDataSourceContainer;
+import org.jkiss.dbeaver.model.app.DBPDataSourceRegistry;
+import org.jkiss.dbeaver.model.app.DBPProject;
+import org.jkiss.dbeaver.model.auth.SMObjectType;
+import org.jkiss.dbeaver.registry.DataSourceNavigatorSettings;
+import org.jkiss.dbeaver.registry.project.BaseProjectSettings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+class BaseProjectSettingsTest {
+    private static final String DATA_SOURCE_ID = "ds1";
+
+    private DBPDataSourceRegistry registry;
+    private BaseProjectSettings projectSettings;
+
+    @BeforeEach
+    void setUp() {
+        DBPProject project = Mockito.mock(DBPProject.class);
+        registry = Mockito.mock(DBPDataSourceRegistry.class);
+        DBPDataSourceContainer dataSource = Mockito.mock(DBPDataSourceContainer.class);
+        Mockito.when(project.getDataSourceRegistry()).thenReturn(registry);
+        Mockito.when(registry.getDataSource(DATA_SOURCE_ID)).thenReturn(dataSource);
+        Mockito.when(dataSource.getRegistry()).thenReturn(registry);
+        Mockito.when(dataSource.getId()).thenReturn(DATA_SOURCE_ID);
+        projectSettings = new BaseProjectSettings(project) {
+            @NotNull
+            @Override
+            protected Map<SMObjectType, Map<String, Map<String, String>>> loadAllProjectSettings() {
+                return new LinkedHashMap<>();
+            }
+
+            @Override
+            protected void saveProjectSettings(
+                @NotNull SMObjectType objectType,
+                @NotNull String objectId,
+                @NotNull Map<String, String> settings
+            ) {
+            }
+        };
+    }
+
+    @Test
+    void invalidatesNavigatorSettingsWhenCacheIsNotInitialized() {
+        deleteNavigatorSettings();
+
+        Mockito.verify(registry).refreshConfig(List.of(DATA_SOURCE_ID));
+    }
+
+    @Test
+    void invalidatesNavigatorSettingsWhenCacheDoesNotContainObject() {
+        projectSettings.getObjectSettings(SMObjectType.datasource, DATA_SOURCE_ID);
+
+        deleteNavigatorSettings();
+
+        Mockito.verify(registry).refreshConfig(List.of(DATA_SOURCE_ID));
+    }
+
+    private void deleteNavigatorSettings() {
+        projectSettings.deleteObjectSettingsCache(
+            SMObjectType.datasource,
+            DATA_SOURCE_ID,
+            DataSourceNavigatorSettings.NAVIGATOR_SETTINGS
+        );
+    }
+}

--- a/server/test/io.cloudbeaver.test.platform/src/io/cloudbeaver/model/session/BaseProjectSettingsTest.java
+++ b/server/test/io.cloudbeaver.test.platform/src/io/cloudbeaver/model/session/BaseProjectSettingsTest.java
@@ -59,6 +59,7 @@ class BaseProjectSettingsTest {
                 @NotNull String objectId,
                 @NotNull Map<String, String> settings
             ) {
+                throw new UnsupportedOperationException();
             }
         };
     }

--- a/server/test/io.cloudbeaver.test.platform/src/io/cloudbeaver/model/session/WebSessionProjectTest.java
+++ b/server/test/io.cloudbeaver.test.platform/src/io/cloudbeaver/model/session/WebSessionProjectTest.java
@@ -29,6 +29,7 @@ import org.jkiss.dbeaver.model.rm.RMProjectType;
 import org.jkiss.dbeaver.model.websocket.event.datasource.WSDataSourceEvent;
 import org.jkiss.dbeaver.model.websocket.event.datasource.WSDataSourceProperty;
 import org.jkiss.dbeaver.registry.DataSourceDescriptor;
+import org.jkiss.dbeaver.registry.DataSourceNavigatorSettings;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -179,6 +180,52 @@ public class WebSessionProjectTest extends CloudbeaverMockTest {
         Mockito.when(event.getProperty()).thenReturn(WSDataSourceProperty.INTERNAL);
         Assertions.assertFalse(project.updateProjectDataSources(event));
 
+    }
+
+    @Test
+    public void testUpdateProjectDataSourcesIgnoresIneffectiveUpdate() {
+        DBPDataSourceRegistry registry = Mockito.mock(DBPDataSourceRegistry.class);
+        DataSourceDescriptor ds = Mockito.mock(DataSourceDescriptor.class);
+        DataSourceDescriptor snapshot = Mockito.mock(DataSourceDescriptor.class);
+        Mockito.when(registry.getDataSource("ds1")).thenReturn(ds);
+        Mockito.when(registry.createDataSource(ds)).thenReturn(snapshot);
+        Mockito.when(snapshot.equalConfiguration(ds)).thenReturn(true);
+
+        WebSessionProjectImpl project = new WebSessionProjectImpl(webSession, rmProject) {
+            @NotNull
+            @Override
+            public DBPDataSourceRegistry getDataSourceRegistry() {
+                return registry;
+            }
+        };
+
+        WSDataSourceEvent event = Mockito.mock(WSDataSourceEvent.class);
+        Mockito.when(event.getId()).thenReturn(WSDataSourceEvent.UPDATED);
+        Mockito.when(event.getDataSourceIds()).thenReturn(List.of("ds1"));
+        Mockito.when(event.getProperty()).thenReturn(WSDataSourceProperty.CONFIGURATION);
+
+        Assertions.assertFalse(project.updateProjectDataSources(event));
+        Mockito.verify(registry).refreshConfig(List.of("ds1"));
+    }
+
+    @Test
+    public void testNavigatorSettingsIgnoreOriginalSettingsWhenComparingEffectiveSettings() {
+        DataSourceNavigatorSettings oldSettings = new DataSourceNavigatorSettings();
+        oldSettings.setShowOnlyEntities(true);
+        DataSourceNavigatorSettings oldOriginalSettings = new DataSourceNavigatorSettings();
+        oldOriginalSettings.setShowSystemObjects(true);
+        oldSettings.setOriginalSettings(oldOriginalSettings);
+
+        DataSourceNavigatorSettings newSettings = new DataSourceNavigatorSettings();
+        newSettings.setShowOnlyEntities(true);
+        DataSourceNavigatorSettings newOriginalSettings = new DataSourceNavigatorSettings();
+        newOriginalSettings.setHideFolders(true);
+        newSettings.setOriginalSettings(newOriginalSettings);
+
+        Assertions.assertTrue(oldSettings.isUserSettings());
+        Assertions.assertTrue(newSettings.isUserSettings());
+        Assertions.assertNotEquals(oldSettings.getOriginalSettings(), newSettings.getOriginalSettings());
+        Assertions.assertEquals(oldSettings, newSettings);
     }
 
     @Test


### PR DESCRIPTION
Closes dbeaver/pro#8982

Captures data source state before refreshing shared configuration and suppresses frontend events and disconnects when user overrides keep the effective configuration unchanged. Adds focused regression coverage.

Depends on dbeaver/dbeaver#41841.

Testing: `mvn verify -f server/product/aggregate/pom.xml -T 1C`

This PR was generated with AI (OpenCode).