### PR TITLE
dbeaver/pro#10479 Reuse application launch parameters

### DIFF
--- a/server/product/web-server-test/CloudbeaverServerUnitTest.product
+++ b/server/product/web-server-test/CloudbeaverServerUnitTest.product
@@ -13,28 +13,7 @@
         <vmArgs>
             -Dfile.encoding=UTF-8
             --sun-misc-unsafe-memory-access=allow
-            --enable-native-access=ALL-UNNAMED
-            --add-modules=ALL-DEFAULT
-            --add-opens=java.base/java.io=ALL-UNNAMED
-            --add-opens=java.base/java.lang=ALL-UNNAMED
-            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
-            --add-opens=java.base/java.net=ALL-UNNAMED
-            --add-opens=java.base/java.nio=ALL-UNNAMED
-            --add-opens=java.base/java.nio.charset=ALL-UNNAMED
-            --add-opens=java.base/java.text=ALL-UNNAMED
-            --add-opens=java.base/java.time=ALL-UNNAMED
-            --add-opens=java.base/java.util=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
-            --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED
-            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
-            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
-            --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
-            --add-opens=java.base/sun.security.util=ALL-UNNAMED
-            --add-opens=java.security.jgss/sun.security.jgss=ALL-UNNAMED
-            --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
-            --add-opens=java.sql/java.sql=ALL-UNNAMED
+            <!-- dbeaver-launch-parameters: common -->
         </vmArgs>
         <vmArgsMac></vmArgsMac>
     </launcherArgs>

--- a/server/product/web-server-test/pom.xml
+++ b/server/product/web-server-test/pom.xml
@@ -17,6 +17,18 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.jkiss.dbeaver</groupId>
+                <artifactId>product-generator</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-p2-publisher-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <productsDirectory>${project.build.directory}/generated-products</productsDirectory>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>target-platform-configuration</artifactId>
                 <version>${tycho-version}</version>

--- a/server/product/web-server/CloudbeaverServer.product
+++ b/server/product/web-server/CloudbeaverServer.product
@@ -13,28 +13,7 @@
         <vmArgs>
             -Dfile.encoding=UTF-8 
             --sun-misc-unsafe-memory-access=allow
-            --enable-native-access=ALL-UNNAMED
-            --add-modules=ALL-DEFAULT
-            --add-opens=java.base/java.io=ALL-UNNAMED
-            --add-opens=java.base/java.lang=ALL-UNNAMED
-            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
-            --add-opens=java.base/java.net=ALL-UNNAMED
-            --add-opens=java.base/java.nio=ALL-UNNAMED
-            --add-opens=java.base/java.nio.charset=ALL-UNNAMED
-            --add-opens=java.base/java.text=ALL-UNNAMED
-            --add-opens=java.base/java.time=ALL-UNNAMED
-            --add-opens=java.base/java.util=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
-            --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED
-            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
-            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
-            --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
-            --add-opens=java.base/sun.security.util=ALL-UNNAMED
-            --add-opens=java.security.jgss/sun.security.jgss=ALL-UNNAMED
-            --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
-            --add-opens=java.sql/java.sql=ALL-UNNAMED
+            <!-- dbeaver-launch-parameters: common -->
         </vmArgs>
         <vmArgsMac></vmArgsMac>
     </launcherArgs>

--- a/server/product/web-server/pom.xml
+++ b/server/product/web-server/pom.xml
@@ -17,6 +17,18 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.jkiss.dbeaver</groupId>
+                <artifactId>product-generator</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-p2-publisher-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <productsDirectory>${project.build.directory}/generated-products</productsDirectory>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>target-platform-configuration</artifactId>
                 <version>${tycho-version}</version>


### PR DESCRIPTION
Closes dbeaver/pro#10479

Depends on dbeaver/dbeaver#41977.

## Summary
- replace duplicated CloudBeaver server launch parameters with the common generated set
- generate production and unit-test product descriptors before Tycho publication
- preserve server-specific configuration arguments

## Testing
- generated the CloudBeaver server descriptor with the product generator

This PR was generated with AI (OpenCode).