### PR TITLE
dbeaver/pro#10370 Deleted used Connection type remains applied

### DIFF
--- a/server/bundles/io.cloudbeaver.server/src/io/cloudbeaver/server/events/WSEventHandlerWorkspaceConfigUpdate.java
+++ b/server/bundles/io.cloudbeaver.server/src/io/cloudbeaver/server/events/WSEventHandlerWorkspaceConfigUpdate.java
@@ -16,10 +16,13 @@
  */
 package io.cloudbeaver.server.events;
 
+import io.cloudbeaver.WebSessionProjectImpl;
+import io.cloudbeaver.model.session.BaseWebSession;
 import org.jkiss.code.NotNull;
 import org.jkiss.dbeaver.Log;
 import org.jkiss.dbeaver.model.WorkspaceConfigEventManager;
 import org.jkiss.dbeaver.model.websocket.event.WSWorkspaceConfigurationChangedEvent;
+import org.jkiss.dbeaver.registry.RegistryConstants;
 
 public class WSEventHandlerWorkspaceConfigUpdate extends WSDefaultEventHandler<WSWorkspaceConfigurationChangedEvent> {
     private static final Log log = Log.getLog(WSEventHandlerWorkspaceConfigUpdate.class);
@@ -30,5 +33,30 @@ public class WSEventHandlerWorkspaceConfigUpdate extends WSDefaultEventHandler<W
         log.info("Config file changed: " + configFileName);
         WorkspaceConfigEventManager.fireConfigChangedEvent(configFileName);
         super.handleEvent(event);
+    }
+
+    @Override
+    protected void updateSessionData(
+        @NotNull BaseWebSession activeUserSession,
+        @NotNull WSWorkspaceConfigurationChangedEvent event
+    ) {
+        if (isConnectionTypesConfig(event)) {
+            for (WebSessionProjectImpl project : activeUserSession.getWorkspace().getProjects()) {
+                project.getDataSourceRegistry().refreshConfig();
+            }
+        }
+        super.updateSessionData(activeUserSession, event);
+    }
+
+    @Override
+    protected boolean isAcceptableInSession(
+        @NotNull BaseWebSession activeUserSession,
+        @NotNull WSWorkspaceConfigurationChangedEvent event
+    ) {
+        return isConnectionTypesConfig(event) || super.isAcceptableInSession(activeUserSession, event);
+    }
+
+    private static boolean isConnectionTypesConfig(@NotNull WSWorkspaceConfigurationChangedEvent event) {
+        return RegistryConstants.CONNECTION_TYPES_FILE_NAME.equals(event.getConfigFilePath());
     }
 }

--- a/server/test/io.cloudbeaver.test.platform/src/io/cloudbeaver/server/events/WSEventHandlerWorkspaceConfigUpdateTest.java
+++ b/server/test/io.cloudbeaver.test.platform/src/io/cloudbeaver/server/events/WSEventHandlerWorkspaceConfigUpdateTest.java
@@ -1,0 +1,80 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudbeaver.server.events;
+
+import io.cloudbeaver.WebSessionProjectImpl;
+import io.cloudbeaver.model.session.BaseWebSession;
+import io.cloudbeaver.model.session.WebSessionWorkspace;
+import org.jkiss.code.NotNull;
+import org.jkiss.dbeaver.model.app.DBPDataSourceRegistry;
+import org.jkiss.dbeaver.model.websocket.event.WSWorkspaceConfigurationChangedEvent;
+import org.jkiss.dbeaver.registry.RegistryConstants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+public class WSEventHandlerWorkspaceConfigUpdateTest {
+    @Test
+    public void testConnectionTypeEventRefreshesEveryProjectInSourceSession() {
+        String sessionId = "session-id";
+        BaseWebSession session = Mockito.mock(BaseWebSession.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(session.getUserContext().getSmSessionId()).thenReturn(sessionId);
+
+        WebSessionProjectImpl firstProject = Mockito.mock(WebSessionProjectImpl.class);
+        WebSessionProjectImpl secondProject = Mockito.mock(WebSessionProjectImpl.class);
+        DBPDataSourceRegistry firstRegistry = Mockito.mock(DBPDataSourceRegistry.class);
+        DBPDataSourceRegistry secondRegistry = Mockito.mock(DBPDataSourceRegistry.class);
+        Mockito.when(firstProject.getDataSourceRegistry()).thenReturn(firstRegistry);
+        Mockito.when(secondProject.getDataSourceRegistry()).thenReturn(secondRegistry);
+
+        WebSessionWorkspace workspace = Mockito.mock(WebSessionWorkspace.class);
+        Mockito.when(workspace.getProjects()).thenReturn(List.of(firstProject, secondProject));
+        Mockito.when(session.getWorkspace()).thenReturn(workspace);
+
+        WSWorkspaceConfigurationChangedEvent event = new WSWorkspaceConfigurationChangedEvent(
+            RegistryConstants.CONNECTION_TYPES_FILE_NAME,
+            sessionId,
+            "user-id"
+        );
+        TestEventHandler handler = new TestEventHandler();
+
+        Assertions.assertTrue(handler.accepts(session, event));
+        handler.update(session, event);
+
+        Mockito.verify(firstRegistry).refreshConfig();
+        Mockito.verify(secondRegistry).refreshConfig();
+        Mockito.verify(session).addSessionEvent(event);
+    }
+
+    private static final class TestEventHandler extends WSEventHandlerWorkspaceConfigUpdate {
+        private boolean accepts(
+            @NotNull BaseWebSession session,
+            @NotNull WSWorkspaceConfigurationChangedEvent event
+        ) {
+            return isAcceptableInSession(session, event);
+        }
+
+        private void update(
+            @NotNull BaseWebSession session,
+            @NotNull WSWorkspaceConfigurationChangedEvent event
+        ) {
+            updateSessionData(session, event);
+        }
+    }
+}

--- a/server/test/io.cloudbeaver.test.platform/src/io/cloudbeaver/test/platform/CEServerTestSuite.java
+++ b/server/test/io.cloudbeaver.test.platform/src/io/cloudbeaver/test/platform/CEServerTestSuite.java
@@ -24,6 +24,7 @@ import io.cloudbeaver.model.rm.local.LocalResourceControllerTest;
 import io.cloudbeaver.model.rm.lock.RMLockTest;
 import io.cloudbeaver.model.session.WebSessionProjectTest;
 import io.cloudbeaver.model.session.WebSessionTest;
+import io.cloudbeaver.server.events.WSEventHandlerWorkspaceConfigUpdateTest;
 import io.cloudbeaver.test.platform.admin.AdminCreateUserTest;
 import io.cloudbeaver.test.platform.admin.AdminImportUsersTest;
 import io.cloudbeaver.test.platform.admin.AdminLastLoginTimeTest;
@@ -46,6 +47,7 @@ import org.junit.platform.suite.api.Suite;
         NoSessionTest.class,
         WebSessionTest.class,
         WebSessionProjectTest.class,
+        WSEventHandlerWorkspaceConfigUpdateTest.class,
         WebNavigatorNodeInfoTest.class,
         AdminCreateUserTest.class,
         AdminImportUsersTest.class,


### PR DESCRIPTION
Closes dbeaver/pro#10370

## Summary
- refresh connection configuration for every project in an active session when connection types change
- deliver connection type updates to the source session
- add regression coverage to the server platform suite

## Testing
- WSEventHandlerWorkspaceConfigUpdateTest (1 test passed)