### PR TITLE
dbeaver/pro#10137 Fix AI chat menu viewport sizing

### DIFF
--- a/webapp/common-react/@dbeaver/ui-kit/src/Menu/Menu.css
+++ b/webapp/common-react/@dbeaver/ui-kit/src/Menu/Menu.css
@@ -38,6 +38,10 @@
     }
   }
 
+  .dbv-kit-menu__popover--fit-viewport {
+    max-height: var(--popover-available-height, var(--dbv-kit-menu-popover-max-height));
+  }
+
   .dbv-kit-menu__item,
   .dbv-kit-menu__dismiss {
     display: block;

--- a/webapp/common-react/@dbeaver/ui-kit/src/Menu/Menu.tsx
+++ b/webapp/common-react/@dbeaver/ui-kit/src/Menu/Menu.tsx
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,12 @@ export function MenuButtonArrow({ className, ...props }: MenuArrowProps): ReactE
 
 export function Menu({ children, className, ...props }: MenuProps): ReactElement {
   return (
-    <AriaMenu className={clsx('dbv-kit-menu__popover', className)} portal={props.portal ?? true} gutter={props.gutter ?? 4} {...props}>
+    <AriaMenu
+      className={clsx('dbv-kit-menu__popover', props.fitViewport && 'dbv-kit-menu__popover--fit-viewport', className)}
+      portal={props.portal ?? true}
+      gutter={props.gutter ?? 4}
+      {...props}
+    >
       {children}
     </AriaMenu>
   );

--- a/webapp/packages/plugin-ai-chat/src/AIChat/AIChatConversation/AIChatConversationScope/AIChatConversationScope.tsx
+++ b/webapp/packages/plugin-ai-chat/src/AIChat/AIChatConversation/AIChatConversationScope/AIChatConversationScope.tsx
@@ -104,7 +104,7 @@ export const AIChatConversationScope = observer<Props>(function AIChatConversati
   return (
     <MenuProvider placement="bottom-end">
       <MenuButton render={<ActionIconButton disabled={disabled} title={translate('plugin_ai_chat_scope_change')} name="/icons/scope.svg" img />} />
-      <Menu modal>
+      <Menu modal fitViewport>
         <MenuGroup className="tw:flex tw:flex-col tw:gap-1">
           <MenuGroupLabel>{translate('plugin_ai_chat_scope_change')}</MenuGroupLabel>
 

--- a/webapp/packages/plugin-ai-chat/src/AIChat/AIChatConversationsHistory.tsx
+++ b/webapp/packages/plugin-ai-chat/src/AIChat/AIChatConversationsHistory.tsx
@@ -82,7 +82,7 @@ export const AIChatConversationsHistory = observer<Props>(function AIChatConvers
           />
         }
       />
-      <Menu modal>
+      <Menu modal fitViewport>
         {conversationGroups.map(([group, groupConversations]) => (
           <MenuGroup key={group}>
             <MenuGroupLabel>{translate(getGroupLabel(group as EConversationGroup))}</MenuGroupLabel>


### PR DESCRIPTION
Closes dbeaver/pro#10137

## Summary
- add opt-in viewport-height sizing to the shared `Menu` when Ariakit `fitViewport` is enabled
- enable viewport fitting for the AI profile/scope menu and conversation history
- preserve the existing sizing and automatic placement behavior for all other menus

## Why this approach
The previous fix applied `--popover-available-height` globally. For a context menu initially placed below its anchor, Ariakit reports only the space available below. Restricting the menu to that height makes it fit by scrolling, so collision detection no longer flips it above the anchor. This caused dbeaver/pro#10417 in DB Navigator and the data grid.

This change makes available-height sizing opt-in. Long AI menus use the available viewport height and remain fully reachable through scrolling, while connection-tree, data-grid, and other context menus retain their natural height and can flip upward when there is insufficient space below.

## Affected areas
- AI chat profile/scope menu
- AI chat conversation history
- shared Menu behavior only when `fitViewport` is explicitly set

## Verification
- `yarn workspace @dbeaver/ui-kit build`
- `yarn workspace @cloudbeaver/plugin-ai-chat build`
- ESLint for changed TypeScript files
- Prettier check
- CloudBeaver production bundle
- `git diff --check`