### PR TITLE
dbeaver/cloudbeaver#4648 Fix polling fallback after WebSocket closes

### DIFF
--- a/webapp/packages/core-root/src/TransportSubject.test.ts
+++ b/webapp/packages/core-root/src/TransportSubject.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { Subject } from 'rxjs';
-import { webSocket, type WebSocketSubjectConfig } from 'rxjs/webSocket';
+import { webSocket } from 'rxjs/webSocket';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { EnvironmentService } from '@cloudbeaver/core-sdk';
@@ -30,23 +30,14 @@ interface ITestEvent {
 describe('TransportSubject', () => {
   let websocketSubject: Subject<ITestEvent>;
   let pollingSubject: Subject<ITestEvent>;
-  let websocketConfig: WebSocketSubjectConfig<ITestEvent>;
-  let startPolling: () => void;
 
   beforeEach(() => {
     (globalThis as any)._ROOT_URI_ = '{ROOT_URI}';
     websocketSubject = new Subject();
     pollingSubject = new Subject();
 
-    vi.mocked(webSocket).mockImplementation(config => {
-      websocketConfig = config as WebSocketSubjectConfig<ITestEvent>;
-      return websocketSubject as never;
-    });
-
-    vi.mocked(longPolling).mockImplementation(options => {
-      startPolling = () => options.startObserver?.next();
-      return pollingSubject as never;
-    });
+    vi.mocked(webSocket).mockReturnValue(websocketSubject as never);
+    vi.mocked(longPolling).mockReturnValue(pollingSubject as never);
 
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
   });

--- a/webapp/packages/core-root/src/TransportSubject.test.ts
+++ b/webapp/packages/core-root/src/TransportSubject.test.ts
@@ -23,14 +23,14 @@ vi.mock('./longPolling.js', () => ({
   longPolling: vi.fn(),
 }));
 
-interface TestEvent {
+interface ITestEvent {
   id: string;
 }
 
 describe('TransportSubject', () => {
-  let websocketSubject: Subject<TestEvent>;
-  let pollingSubject: Subject<TestEvent>;
-  let websocketConfig: WebSocketSubjectConfig<TestEvent>;
+  let websocketSubject: Subject<ITestEvent>;
+  let pollingSubject: Subject<ITestEvent>;
+  let websocketConfig: WebSocketSubjectConfig<ITestEvent>;
   let startPolling: () => void;
 
   beforeEach(() => {
@@ -39,7 +39,7 @@ describe('TransportSubject', () => {
     pollingSubject = new Subject();
 
     vi.mocked(webSocket).mockImplementation(config => {
-      websocketConfig = config as WebSocketSubjectConfig<TestEvent>;
+      websocketConfig = config as WebSocketSubjectConfig<ITestEvent>;
       return websocketSubject as never;
     });
 
@@ -52,6 +52,7 @@ describe('TransportSubject', () => {
   });
 
   afterEach(() => {
+    (globalThis as any)._ROOT_URI_ = undefined;
     vi.restoreAllMocks();
   });
 
@@ -98,20 +99,6 @@ describe('TransportSubject', () => {
     expect(pollingNext).toHaveBeenCalledWith(event);
   });
 
-  it('reports readiness for each activated transport', () => {
-    const transport = createTransport();
-    const ready = vi.fn();
-
-    transport.ready$.subscribe(ready);
-    transport.subscribe();
-
-    websocketConfig.openObserver?.next(new Event('open'));
-    websocketSubject.complete();
-    startPolling();
-
-    expect(ready).toHaveBeenCalledTimes(2);
-  });
-
   it('does not activate polling during explicit teardown', () => {
     const transport = createTransport();
 
@@ -134,6 +121,6 @@ describe('TransportSubject', () => {
   });
 });
 
-function createTransport(): TransportSubject<TestEvent> {
-  return new TransportSubject<TestEvent>({ wsEndpoint: 'ws://localhost/api/ws' } as EnvironmentService);
+function createTransport(): TransportSubject<ITestEvent> {
+  return new TransportSubject<ITestEvent>({ wsEndpoint: 'ws://localhost/api/ws' } as EnvironmentService);
 }

--- a/webapp/packages/core-root/src/TransportSubject.test.ts
+++ b/webapp/packages/core-root/src/TransportSubject.test.ts
@@ -1,0 +1,139 @@
+/*
+ * CloudBeaver - Cloud Database Manager
+ * Copyright (C) 2020-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * you may not use this file except in compliance with the License.
+ */
+
+import { Subject } from 'rxjs';
+import { webSocket, type WebSocketSubjectConfig } from 'rxjs/webSocket';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EnvironmentService } from '@cloudbeaver/core-sdk';
+
+import { longPolling } from './longPolling.js';
+import { TransportSubject } from './TransportSubject.js';
+
+vi.mock('rxjs/webSocket', () => ({
+  webSocket: vi.fn(),
+}));
+
+vi.mock('./longPolling.js', () => ({
+  longPolling: vi.fn(),
+}));
+
+interface TestEvent {
+  id: string;
+}
+
+describe('TransportSubject', () => {
+  let websocketSubject: Subject<TestEvent>;
+  let pollingSubject: Subject<TestEvent>;
+  let websocketConfig: WebSocketSubjectConfig<TestEvent>;
+  let startPolling: () => void;
+
+  beforeEach(() => {
+    (globalThis as any)._ROOT_URI_ = '{ROOT_URI}';
+    websocketSubject = new Subject();
+    pollingSubject = new Subject();
+
+    vi.mocked(webSocket).mockImplementation(config => {
+      websocketConfig = config as WebSocketSubjectConfig<TestEvent>;
+      return websocketSubject as never;
+    });
+
+    vi.mocked(longPolling).mockImplementation(options => {
+      startPolling = () => options.startObserver?.next();
+      return pollingSubject as never;
+    });
+
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('switches to polling when the WebSocket closes cleanly', () => {
+    const transport = createTransport();
+    const next = vi.fn();
+    const complete = vi.fn();
+
+    transport.subscribe({ next, complete });
+    websocketSubject.complete();
+
+    const event = { id: 'event' };
+    pollingSubject.next(event);
+
+    expect(next).toHaveBeenCalledWith(event);
+    expect(complete).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith('WebSocket closed, switching to polling');
+  });
+
+  it('keeps switching to polling when the WebSocket errors', () => {
+    const transport = createTransport();
+    const next = vi.fn();
+
+    transport.subscribe(next);
+    websocketSubject.error(new Error('WebSocket failed'));
+
+    const event = { id: 'event' };
+    pollingSubject.next(event);
+
+    expect(next).toHaveBeenCalledWith(event);
+    expect(console.warn).toHaveBeenCalledWith('WebSocket failed, switching to polling');
+  });
+
+  it('sends events through polling after switching transports', () => {
+    const transport = createTransport();
+    const pollingNext = vi.spyOn(pollingSubject, 'next');
+
+    transport.subscribe();
+    websocketSubject.complete();
+
+    const event = { id: 'event' };
+    transport.next(event);
+
+    expect(pollingNext).toHaveBeenCalledWith(event);
+  });
+
+  it('reports readiness for each activated transport', () => {
+    const transport = createTransport();
+    const ready = vi.fn();
+
+    transport.ready$.subscribe(ready);
+    transport.subscribe();
+
+    websocketConfig.openObserver?.next(new Event('open'));
+    websocketSubject.complete();
+    startPolling();
+
+    expect(ready).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not activate polling during explicit teardown', () => {
+    const transport = createTransport();
+
+    transport.subscribe();
+    transport.unsubscribe();
+
+    expect(pollingSubject.observed).toBe(false);
+  });
+
+  it('propagates polling errors instead of switching again', () => {
+    const transport = createTransport();
+    const error = vi.fn();
+    const pollingError = new Error('Polling failed');
+
+    transport.subscribe({ error });
+    websocketSubject.complete();
+    pollingSubject.error(pollingError);
+
+    expect(error).toHaveBeenCalledWith(pollingError);
+  });
+});
+
+function createTransport(): TransportSubject<TestEvent> {
+  return new TransportSubject<TestEvent>({ wsEndpoint: 'ws://localhost/api/ws' } as EnvironmentService);
+}

--- a/webapp/packages/core-root/src/TransportSubject.ts
+++ b/webapp/packages/core-root/src/TransportSubject.ts
@@ -1,12 +1,12 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
  */
 
-import { catchError, EMPTY, Observable, shareReplay, Subject, Subscriber, Subscription, take, throwError } from 'rxjs';
+import { catchError, EMPTY, Observable, shareReplay, Subject, Subscriber, Subscription, throwError } from 'rxjs';
 import { webSocket } from 'rxjs/webSocket';
 
 import type { EnvironmentService } from '@cloudbeaver/core-sdk';
@@ -32,7 +32,7 @@ export class TransportSubject<T> extends Subject<T> {
     this.output = new Subject();
     this.ready = new Subject();
 
-    this.ready$ = this.ready.pipe(take(1), shareReplay(1));
+    this.ready$ = this.ready.pipe(shareReplay(1));
 
     this.sub = null;
 
@@ -82,8 +82,7 @@ export class TransportSubject<T> extends Subject<T> {
           if (this.active === this.ws) {
             console.warn('WebSocket failed, switching to polling');
 
-            this.active = this.poll;
-            this.connect();
+            this.switchToPolling();
             return EMPTY;
           }
 
@@ -93,8 +92,21 @@ export class TransportSubject<T> extends Subject<T> {
       .subscribe({
         next: value => this.output.next(value),
         error: err => this.output.error(err),
-        complete: () => this.output.complete(),
+        complete: () => {
+          if (this.active === this.ws) {
+            console.warn('WebSocket closed, switching to polling');
+            this.switchToPolling();
+            return;
+          }
+
+          this.output.complete();
+        },
       });
+  }
+
+  private switchToPolling(): void {
+    this.active = this.poll;
+    this.connect();
   }
 
   override unsubscribe(): void {

--- a/webapp/packages/core-root/src/TransportSubject.ts
+++ b/webapp/packages/core-root/src/TransportSubject.ts
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  */
 
-import { catchError, EMPTY, Observable, shareReplay, Subject, Subscriber, Subscription, throwError } from 'rxjs';
+import { catchError, EMPTY, Observable, shareReplay, Subject, Subscriber, Subscription, take, throwError } from 'rxjs';
 import { webSocket } from 'rxjs/webSocket';
 
 import type { EnvironmentService } from '@cloudbeaver/core-sdk';
@@ -32,7 +32,7 @@ export class TransportSubject<T> extends Subject<T> {
     this.output = new Subject();
     this.ready = new Subject();
 
-    this.ready$ = this.ready.pipe(shareReplay(1));
+    this.ready$ = this.ready.pipe(take(1), shareReplay(1));
 
     this.sub = null;
 


### PR DESCRIPTION
Closes #4648

## Summary

RxJS reports a clean WebSocket close through `complete`, bypassing the existing error-based fallback. `TransportSubject` therefore completed instead of switching to long polling.

This change:

  - Switches to long polling when the WebSocket completes.
  - Preserves intentional teardown behavior.
  - Adds regression tests for transport fallback and lifecycle behavior.

## Testing

  - Added focused `TransportSubject` unit tests.
  - Full frontend suite passed: 748 passed, 27 skipped.
  - Production frontend bundle completed successfully.