### PR TITLE
dbeaver/pro#9864 be aware of DBNRoot

### DIFF
--- a/webapp/packages/core-navigation-tree/src/NodesManager/NavNodeInfoResource.ts
+++ b/webapp/packages/core-navigation-tree/src/NodesManager/NavNodeInfoResource.ts
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2024 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,17 @@ export class NavNodeInfoResource extends CachedMapResource<string, NavNode, Reco
     while (current && current.parentId !== undefined) {
       parents.unshift(current.parentId);
       current = this.get(current.parentId);
+    }
+
+    return parents;
+  }
+
+  async resolveParents(key: string): Promise<string[]> {
+    let parents = this.getParents(key);
+
+    if (key !== ROOT_NODE_PATH && !parents.includes(ROOT_NODE_PATH)) {
+      await this.loadNodeParents(key);
+      parents = this.getParents(key);
     }
 
     return parents;
@@ -169,15 +180,15 @@ export class NavNodeInfoResource extends CachedMapResource<string, NavNode, Reco
     });
 
     return runInAction(() => {
-      const navNode = this.navNodeInfoToNavNode(node, parents[0]?.uri);
+      // The API returns parents from closest to farthest and omits DBNRoot.
+      // Append ROOT_NODE_PATH to complete the parent chain stored by the frontend.
+      const parentUris = [...parents.map(parent => parent.uri), ROOT_NODE_PATH];
+      const nodeParentId = node.uri === ROOT_NODE_PATH ? undefined : parentUris[0];
 
-      this.set(resourceKeyList([...parents.map(node => node.uri), navNode.uri]), [
-        ...parents.reduce((list, node, index, array) => {
-          list.push(this.navNodeInfoToNavNode(node, array[index + 1]?.uri));
-          return list;
-        }, [] as NavNode[]),
-        navNode,
-      ]);
+      const navNode = this.navNodeInfoToNavNode(node, nodeParentId);
+      const navParents = parents.map((parent, index) => this.navNodeInfoToNavNode(parent, parentUris[index + 1]));
+
+      this.set(resourceKeyList([...parents.map(parent => parent.uri), navNode.uri]), [...navParents, navNode]);
       return navNode;
     });
   }

--- a/webapp/packages/plugin-connections/src/NavNodes/ConnectionFoldersBootstrap.ts
+++ b/webapp/packages/plugin-connections/src/NavNodes/ConnectionFoldersBootstrap.ts
@@ -356,7 +356,7 @@ export class ConnectionFoldersBootstrap extends Bootstrap {
 
             const newFolderId = getConnectionFolderId(createConnectionFolderParam(result.projectId, createPath(result.folder, result.name)));
             await this.navNodeInfoResource.loadNodeParents(newFolderId);
-            await this.navigationTreeService.showNode(newFolderId, this.navNodeInfoResource.getParents(newFolderId));
+            await this.navigationTreeService.showNode(newFolderId);
           } catch (exception: any) {
             this.notificationService.logException(exception, "Can't create folder");
           }

--- a/webapp/packages/plugin-connections/src/NavNodes/ConnectionNavNodeService.ts
+++ b/webapp/packages/plugin-connections/src/NavNodes/ConnectionNavNodeService.ts
@@ -280,7 +280,7 @@ export class ConnectionNavNodeService {
       this.navTreeResource.insertToNode(parentId, insertIndex, connection.nodePath);
     } finally {
       await this.navNodeInfoResource.loadNodeParents(connection.nodePath);
-      await this.navigationTreeService.showNode(connection.nodePath, this.navNodeInfoResource.getParents(connection.nodePath));
+      await this.navigationTreeService.showNode(connection.nodePath);
     }
   }
 

--- a/webapp/packages/plugin-navigation-tree/src/NavigationTree/NavigationTreeService.ts
+++ b/webapp/packages/plugin-navigation-tree/src/NavigationTree/NavigationTreeService.ts
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,8 @@ export class NavigationTreeService extends View<string> {
     await this.navNodeManagerService.navToNode(id, parentId);
   }
 
-  async showNode(id: string, path: string[]): Promise<void> {
+  async showNode(id: string): Promise<void> {
+    const path = await this.navNodeInfoResource.resolveParents(id);
     await this.showNodeExecutor.execute({ id, path });
   }
 

--- a/webapp/packages/plugin-object-viewer-nav-tree-link/src/ObjectViewerNavTreeLinkMenuService.ts
+++ b/webapp/packages/plugin-object-viewer-nav-tree-link/src/ObjectViewerNavTreeLinkMenuService.ts
@@ -1,6 +1,6 @@
 /*
  * CloudBeaver - Cloud Database Manager
- * Copyright (C) 2020-2025 DBeaver Corp and others
+ * Copyright (C) 2020-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0.
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,7 @@ export class ObjectViewerNavTreeLinkMenuService extends Bootstrap {
         const tree = context.get(DATA_CONTEXT_ELEMENTS_TREE)!;
 
         const navNode = this.connectionSchemaManagerService.activeNavNode;
-        const nodeInTree = navNode?.path.includes(tree.baseRoot);
-        return !nodeInTree;
+        return !navNode?.nodeId.startsWith(tree.baseRoot);
       },
       handler: this.elementsTreeActionHandler.bind(this),
     });
@@ -82,7 +81,7 @@ export class ObjectViewerNavTreeLinkMenuService extends Bootstrap {
         const navNode = this.connectionSchemaManagerService.activeNavNode;
 
         if (navNode) {
-          await this.navigationTreeService.showNode(navNode.nodeId, navNode.path);
+          await this.navigationTreeService.showNode(navNode.nodeId);
         }
 
         break;


### PR DESCRIPTION
closes [9864](https://github.com/dbeaver/pro/issues/9864)

Fixed navigation path restoration after relogin and with a cold cache. Parent chains are now completed with the node:// root omitted by the backend, while NavigationTreeService.showNode() resolves the current path from the node ID instead of relying on a stored or frontend-generated path. This also prevents the Link with editor action from disappearing before parent nodes are loaded.